### PR TITLE
docs: add MCP policy rationale docs

### DIFF
--- a/docs/Policy/mcp/code_execution.md
+++ b/docs/Policy/mcp/code_execution.md
@@ -1,0 +1,77 @@
+---
+policy_id: mcp_code_execution
+category: mcp
+topic: code_execution
+rules:
+  - id: MCP-009
+    severity: high
+    confidence: 0.85
+    scope: tool
+    fix_type: code
+  - id: MCP-014
+    severity: high
+    confidence: 0.9
+    scope: tool
+    fix_type: code
+references: [LLM05, LLM06]
+---
+
+# Policy Rationale: MCP Dynamic Code Execution
+
+**Policy ID:** `mcp_code_execution`  
+**File:** `mcp/code_execution.yaml`  
+**Rules:** MCP-009, MCP-014  
+**References:** LLM05 (Improper Output Handling), LLM06 (Excessive Agency)
+
+> Shares the dynamic-eval threat model with
+> [openai_sdk/code_execution.md](../openai_sdk/code_execution.md). MCP-specific
+> angle only.
+
+---
+
+## What this policy covers
+
+An MCP tool handler that evaluates dynamic code — Python `eval`/`exec`/`compile`
+(MCP-009, `has_code_exec_call`) or TypeScript `eval()` / `new Function(...)`
+(MCP-014, the captured `code_exec` fact). Both are structured callee matches, not
+substring scans.
+
+## Why eval in an MCP handler is arbitrary code execution
+
+When any portion of the evaluated string flows from the connecting client
+(directly, or via state the model writes), the call is arbitrary code execution
+inside the **MCP server process**: same memory, same imports, same in-process
+credentials, no process boundary between the call and the host. A model steered
+by an untrusted document or a prompt-injected task can reach the primitive and run
+whatever it constructs (LLM06), and the result returns across the trust boundary
+(LLM05).
+
+---
+
+## Rule-by-rule defense
+
+### MCP-009 — Tool body calls eval/exec/compile on dynamic input (Severity: high, Confidence: 0.85, Fix type: code)
+
+**What we detect:** a Python handler invoking `eval`, `exec`, or `compile`.
+
+**Why high / 0.85:** in-process RCE is the most severe tool outcome. Confidence
+0.85 (not higher) because a handler could pass only a fixed literal to `compile`,
+and the structured match flags the call's presence, not proof of dynamic input.
+
+### MCP-014 — TypeScript MCP tool evaluates dynamic code (Severity: high, Confidence: 0.9, Fix type: code)
+
+**What we detect:** a TypeScript handler calling `eval()` or constructing
+`new Function(...)`.
+
+**Why high / 0.9:** same in-process RCE mechanism on the TypeScript SDK; slightly
+higher confidence than MCP-009 because `eval` / `new Function` in TS handlers are
+almost never legitimate, where Python `compile` has a few benign uses.
+
+---
+
+## What this policy does not cover
+
+Whether the evaluated string is genuinely caller-influenced; indirect execution
+via `getattr`/`importlib`/`vm` module/`require` of attacker-named modules; and
+sandboxed evaluators that are still flagged because the rule keys on the call, not
+its safety.

--- a/docs/Policy/mcp/error_handling.md
+++ b/docs/Policy/mcp/error_handling.md
@@ -1,0 +1,57 @@
+---
+policy_id: mcp_error_handling
+category: mcp
+topic: error_handling
+rules:
+  - id: MCP-006
+    severity: medium
+    confidence: 0.6
+    scope: tool
+    fix_type: code
+references: [LLM05]
+---
+
+# Policy Rationale: MCP Error Contract Hygiene
+
+**Policy ID:** `mcp_error_handling`  
+**File:** `mcp/error_handling.yaml`  
+**Rules:** MCP-006  
+**References:** LLM05 (Improper Output Handling)
+
+> Shares the structured-error threat model with
+> [openai_sdk/error_handling.md](../openai_sdk/error_handling.md). MCP-specific
+> angle only.
+
+---
+
+## What this policy covers
+
+An MCP tool handler that can raise without catching, detected by
+`all: [has_raise: true, has_try_except: false]`.
+
+## Rule-by-rule defense
+
+### MCP-006 — Tool raises exceptions without a structured error contract (Severity: medium, Confidence: 0.6, Fix type: code)
+
+**What we detect:** a handler body that contains a `raise` and no `try`/`except`.
+
+**Why it is flaggable:** when an MCP tool handler raises, the runtime surfaces the
+exception to the connecting client as an opaque protocol error. The model on the
+other end often cannot recover or retry intelligently, and the raw message may
+leak internal detail — stack frames, absolute paths, secrets in arguments —
+across the server's trust boundary to whatever client connected (improper output
+handling, LLM05). Medium severity because the impact is degraded recovery plus a
+modest disclosure channel; confidence 0.6 because a handler may raise
+intentionally for a caller that handles it, and the body-only check does not see
+a `try` in a calling frame.
+
+**Fix type — code:** returning a structured `{"error": ..., "retryable": ...}`
+result instead of raising is a source edit.
+
+---
+
+## What this policy does not cover
+
+Whether the raised message actually contains sensitive data; exception handling
+done by a wrapping frame outside the handler body; and the TypeScript MCP error
+surface (no TS raise/catch predicate is wired).

--- a/docs/Policy/mcp/idempotency.md
+++ b/docs/Policy/mcp/idempotency.md
@@ -1,0 +1,60 @@
+---
+policy_id: mcp_idempotency
+category: mcp
+topic: idempotency
+rules:
+  - id: MCP-007
+    severity: medium
+    confidence: 0.55
+    scope: tool
+    fix_type: code
+references: [LLM06]
+---
+
+# Policy Rationale: MCP Mutating-Tool Idempotency
+
+**Policy ID:** `mcp_idempotency`  
+**File:** `mcp/idempotency.yaml`  
+**Rules:** MCP-007  
+**References:** LLM06 (Excessive Agency)
+
+> Shares the retry-safety threat model with
+> [openai_sdk/idempotency.md](../openai_sdk/idempotency.md). MCP-specific angle
+> only.
+
+---
+
+## What this policy covers
+
+A mutating MCP tool — its name carries a side-effect prefix (`create_`, `send_`,
+`delete_`, `post_`, `update_`, `refund_`, `charge_`, `issue_`) — that exposes no
+idempotency-key parameter, detected by `all: [name_has_prefix: [...], not:
+param_name_matches: {contains: [idempot], exact: [request_id, txn_id]}]`.
+
+## Rule-by-rule defense
+
+### MCP-007 — Mutating tool has no idempotency key (Severity: medium, Confidence: 0.55, Fix type: code)
+
+**What we detect:** a side-effect-named handler with no parameter that looks like
+an idempotency key.
+
+**Why it is flaggable:** MCP clients retry tool calls under timeouts and ambiguous
+failures, and the same model may be re-driven to repeat an action. Without an
+idempotency key the handler executes the mutation twice — a duplicate charge,
+order, or message. The excessive-agency framing (LLM06) is that the tool performs
+an irreversible side effect with no replay guard. Medium severity, and confidence
+0.55 because the signal is name-based: a tool named `create_*` may be internally
+idempotent, and a mutating tool with a non-obvious name is missed. The finding is
+a prompt to confirm, not a proof.
+
+**Fix type — code:** accepting an idempotency key and de-duplicating server-side
+is a source edit.
+
+---
+
+## What this policy does not cover
+
+Whether the side effect is genuinely non-idempotent; mutating tools whose names
+carry no recognized prefix; server-side de-duplication achieved without a visible
+key parameter; and the TypeScript MCP surface (the name-prefix predicate runs on
+Python handlers; a TS analogue is not wired in this pack).

--- a/docs/Policy/mcp/network.md
+++ b/docs/Policy/mcp/network.md
@@ -1,0 +1,56 @@
+---
+policy_id: mcp_network
+category: mcp
+topic: network
+rules:
+  - id: MCP-004
+    severity: high
+    confidence: 0.85
+    scope: tool
+    fix_type: code
+references: [LLM10]
+---
+
+# Policy Rationale: MCP Tool Network Hygiene
+
+**Policy ID:** `mcp_network`  
+**File:** `mcp/network.yaml`  
+**Rules:** MCP-004  
+**References:** LLM10 (Unbounded Consumption)
+
+> Shares the timeout threat model with
+> [openai_sdk/network.md](../openai_sdk/network.md). MCP-specific angle only.
+
+---
+
+## What this policy covers
+
+Outbound network calls from inside an MCP tool handler made without a timeout
+(`call_without_kwarg` over the `requests` / `httpx` / `urllib` callee set, with a
+kwarg present as literal `None` counted as missing).
+
+## Rule-by-rule defense
+
+### MCP-004 — Network call has no timeout (Severity: high, Confidence: 0.85, Fix type: code)
+
+**What we detect:** a handler calling an HTTP client method from the recognized
+callee list without a `timeout=` argument (or with `timeout=None`).
+
+**Why it is flaggable:** the MCP runtime does not bound tool execution, so a
+request to a slow or unresponsive host hangs the handler indefinitely. The
+stalled handler blocks the server's reply to the connecting client and ties up
+the worker serving that session — unbounded resource consumption triggered by an
+ordinary tool call. High severity because the failure stalls the whole session,
+not just the one request; confidence 0.85 because the missing-kwarg match is a
+structured AST check, with the residual gap being client aliases reached across
+function or module boundaries (resolved only within a single function today).
+
+**Fix type — code:** adding `timeout=` is a source edit to the handler.
+
+---
+
+## What this policy does not cover
+
+Retries, circuit breaking, and connection-pool exhaustion; aliased clients
+resolved across function/module boundaries; and async HTTP clients whose method
+names are not in the callee set.

--- a/docs/Policy/mcp/path_safety.md
+++ b/docs/Policy/mcp/path_safety.md
@@ -1,0 +1,61 @@
+---
+policy_id: mcp_path_safety
+category: mcp
+topic: path_safety
+rules:
+  - id: MCP-005
+    severity: high
+    confidence: 0.7
+    scope: tool
+    fix_type: code
+references: [LLM02, LLM06]
+---
+
+# Policy Rationale: MCP Filesystem Path Safety
+
+**Policy ID:** `mcp_path_safety`  
+**File:** `mcp/path_safety.yaml`  
+**Rules:** MCP-005  
+**References:** LLM02 (Sensitive Information Disclosure), LLM06 (Excessive Agency)
+
+> Shares the path-traversal threat model with
+> [openai_sdk/path_safety.md](../openai_sdk/path_safety.md). MCP-specific angle
+> only.
+
+---
+
+## What this policy covers
+
+A caller-supplied path-like parameter flowing into an I/O call inside an MCP tool
+handler without containment, detected per-parameter by
+`call_uses_unnormalized_path_param` (callees `open` / `Path`, callee-prefixes
+`shutil.` / `os.`). Per-parameter means a handler that resolves one path but not
+another still fires on the unresolved one.
+
+## Rule-by-rule defense
+
+### MCP-005 — Path parameter used in I/O without validation (Severity: high, Confidence: 0.7, Fix type: code)
+
+**What we detect:** a path-like parameter passed to a file or directory operation
+with no intervening `.resolve()` / containment check.
+
+**Why it is flaggable:** MCP tool arguments are supplied by a connecting client
+and chosen by a model from conversation context. A `../../etc/passwd` traversal
+payload reaches real filesystem state the server can read or write, outside any
+intended root — sensitive-information disclosure (LLM02) driven by the tool's
+excessive filesystem agency (LLM06). High severity because the exposure is direct
+file read/write; confidence 0.7 because the param-is-pathish heuristic can flag a
+parameter that is not actually attacker-influenced, so the finding asks for
+confirmation that the parameter is caller-supplied.
+
+**Fix type — code:** resolving the path and asserting an allowed root is a source
+edit to the handler.
+
+---
+
+## What this policy does not cover
+
+Whether a given parameter is genuinely caller-controlled; containment performed
+by a helper in another module; symlink-escape after a correct `.resolve()`; and
+the TypeScript MCP path surface (no TS path-normalization predicate exists yet —
+TS filesystem risk is approximated only by the shell and code-exec rules).

--- a/docs/Policy/mcp/shell_safety.md
+++ b/docs/Policy/mcp/shell_safety.md
@@ -1,0 +1,82 @@
+---
+policy_id: mcp_shell_safety
+category: mcp
+topic: shell_safety
+rules:
+  - id: MCP-010
+    severity: high
+    confidence: 0.7
+    scope: tool
+    fix_type: code
+  - id: MCP-012
+    severity: high
+    confidence: 0.7
+    scope: tool
+    fix_type: code
+references: [LLM06, LLM05]
+---
+
+# Policy Rationale: MCP Shell Invocation Safety
+
+**Policy ID:** `mcp_shell_safety`  
+**File:** `mcp/shell_safety.yaml`  
+**Rules:** MCP-010, MCP-012  
+**References:** LLM06 (Excessive Agency), LLM05 (Improper Output Handling)
+
+> Shares the process-spawn threat model with
+> [openai_sdk/shell_safety.md](../openai_sdk/shell_safety.md). MCP-specific angle
+> only.
+
+---
+
+## What this policy covers
+
+An MCP tool handler that spawns an OS process — Python `subprocess.*` /
+`os.system` / `os.popen` / `os.spawn*` (MCP-010) or a TypeScript child-process
+API `exec`/`execSync`/`execFile`/`spawn`/`fork`, bare or `child_process.*`
+(MCP-012). Both read the structured `has_shell_call` predicate (Python walks the
+AST; TypeScript reads the `shells_out` fact stamped by `tsHandlerFacts`), so a
+match in a comment or string literal does not fire.
+
+## Why process spawn in an MCP handler is excessive agency
+
+Process spawn from a model-callable MCP tool puts the server host's shell on the
+model's surface with no runtime sandbox. Because a connecting model chooses the
+arguments passed to the tool, a prompt-injected conversation can steer those
+values into a command (LLM06); the subprocess inherits the server host's
+filesystem, environment, and network credentials, and its output returns across
+the trust boundary (LLM05).
+
+---
+
+## Rule-by-rule defense
+
+### MCP-010 — Tool body spawns a subprocess (Severity: high, Confidence: 0.7, Fix type: code)
+
+**What we detect:** a Python handler calling `subprocess.*`, `os.system`,
+`os.popen`, or `os.spawn*`.
+
+**Why high / 0.7:** the fix usually means removing process spawn or rearchitecting
+behind a typed API; partial mitigations narrow injection classes but not the
+excessive-agency core. Confidence 0.7 because some handlers legitimately wrap a
+single fixed command, and the `subprocess.` prefix also catches the non-spawning
+`subprocess.list2cmdline` helper.
+
+### MCP-012 — TypeScript MCP tool spawns a subprocess (Severity: high, Confidence: 0.7, Fix type: code)
+
+**What we detect:** a TypeScript handler invoking a `child_process` API (bare from
+a destructured `const { execSync } = ...` or via `child_process.*`).
+
+**Why high / 0.7:** identical mechanism on the TypeScript SDK. The residual gaps
+are a spawn reached through a renamed alias whose callee text matches no
+recognized name, a helper in another module, or non-`child_process` spawners
+(`Bun.spawn`, `Deno.Command`).
+
+---
+
+## What this policy does not cover
+
+Whether a given literal command is actually safe; spawns hidden behind a
+cross-module helper or a renamed alias; async spawners
+(`asyncio.create_subprocess_*`) and non-`child_process` TypeScript spawners; and
+the HTTP-exfiltration path, which SSRF ([ssrf.md](ssrf.md)) covers.

--- a/docs/Policy/mcp/ssrf.md
+++ b/docs/Policy/mcp/ssrf.md
@@ -1,0 +1,78 @@
+---
+policy_id: mcp_ssrf
+category: mcp
+topic: ssrf
+rules:
+  - id: MCP-008
+    severity: high
+    confidence: 0.6
+    scope: tool
+    fix_type: code
+  - id: MCP-013
+    severity: high
+    confidence: 0.6
+    scope: tool
+    fix_type: code
+references: [LLM06, LLM02]
+---
+
+# Policy Rationale: MCP Server-Side Request Forgery
+
+**Policy ID:** `mcp_ssrf`  
+**File:** `mcp/ssrf.yaml`  
+**Rules:** MCP-008, MCP-013  
+**References:** LLM06 (Excessive Agency), LLM02 (Sensitive Information Disclosure)
+
+> Shares the SSRF threat model with [openai_sdk/ssrf.md](../openai_sdk/ssrf.md).
+> MCP-specific angle only.
+
+---
+
+## What this policy covers
+
+An MCP tool handler issuing an HTTP request to a non-literal URL —
+`has_dynamic_url_call` over the recognized clients (Python `requests`/`httpx`/
+`urllib`; TypeScript `fetch`/`axios`/`got`/`undici` via the captured
+`dynamic_url` handler fact). MCP-008 is the Python rule, MCP-013 the TypeScript
+rule.
+
+## Why SSRF is a server-boundary problem for MCP
+
+An MCP tool argument arrives from a connecting client and is chosen by a model
+from conversation context. If that value flows into the request URL, an attacker
+who can shape the context steers the request at any host the **server** can reach
+but the public internet cannot — cloud metadata endpoints (169.254.169.254) that
+vend credentials, loopback admin APIs, internal services. The MCP server becomes
+a proxy for requests the attacker could not otherwise make (LLM06), and the
+response plus any request body leaks back across the trust boundary (LLM02).
+
+---
+
+## Rule-by-rule defense
+
+### MCP-008 — Tool fetches a caller-controlled URL (SSRF) (Severity: high, Confidence: 0.6, Fix type: code)
+
+**What we detect:** a Python handler whose outbound request URL is built from a
+parameter or an interpolated string rather than a fixed literal.
+
+**Why high / 0.6:** the consequence (credential theft via metadata, internal
+pivot) is severe, so severity is high; confidence is 0.6 because "non-literal
+URL" includes benign cases where the dynamic part is a fixed-base path segment,
+and the rule cannot prove the value is attacker-reachable.
+
+### MCP-013 — TypeScript MCP tool fetches a caller-controlled URL (SSRF) (Severity: high, Confidence: 0.6, Fix type: code)
+
+**What we detect:** the same pattern in a TypeScript handler — a `fetch`/`axios`/
+`got`/`undici` call whose first argument is a template string, identifier, or
+concatenation rather than a string literal (captured `dynamic_url` fact).
+
+**Why high / 0.6:** identical mechanism and calibration to MCP-008 on the
+TypeScript SDK; a plain string-literal URL does not fire.
+
+---
+
+## What this policy does not cover
+
+Whether the dynamic URL is genuinely attacker-controlled vs a fixed-base path;
+allow-list validation the rule cannot see; DNS-rebinding and redirect-based SSRF
+after an initially-safe host; and clients outside the recognized set.

--- a/docs/Policy/mcp/tool_definition.md
+++ b/docs/Policy/mcp/tool_definition.md
@@ -1,0 +1,119 @@
+---
+policy_id: mcp_tool_definition
+category: mcp
+topic: tool_definition
+rules:
+  - id: MCP-001
+    severity: low
+    confidence: 0.9
+    scope: tool
+    fix_type: code
+  - id: MCP-002
+    severity: medium
+    confidence: 0.85
+    scope: tool
+    fix_type: code
+  - id: MCP-003
+    severity: low
+    confidence: 0.85
+    scope: tool
+    fix_type: code
+  - id: MCP-011
+    severity: low
+    confidence: 0.85
+    scope: tool
+    fix_type: code
+references: [LLM06]
+---
+
+# Policy Rationale: MCP Tool Definition Hygiene
+
+**Policy ID:** `mcp_tool_definition`  
+**File:** `mcp/tool_definition.yaml`  
+**Rules:** MCP-001, MCP-002, MCP-003, MCP-011  
+**References:** LLM06 (Excessive Agency)
+
+> Shares the structural-hygiene threat model with
+> [openai_sdk/tool_definition.md](../openai_sdk/tool_definition.md). This
+> document covers the MCP-specific angle only.
+
+---
+
+## What this policy covers
+
+The structural hygiene of Model Context Protocol tool registrations — the
+Python decorator forms (`@server.tool` / `@mcp.tool` / `.register_tool`,
+predicate `mcp_tool` kind) and the TypeScript `@modelcontextprotocol/sdk`
+`server.registerTool(...)` / `server.tool(...)` forms. MCP-001/002/003 are the
+Python rules; MCP-011 is the TypeScript description rule.
+
+## Why definition hygiene is sharper for MCP than for an in-process SDK
+
+An MCP server publishes its tool catalog — names, descriptions, and input
+schemas — across a transport to **whatever client and model connect to it**.
+The author does not control, and often cannot see, the consuming agent. A weak
+description or an unconstrained schema therefore degrades tool selection for
+every consumer of the server, and an ambiguous name collides more easily with
+similarly-named tools from other servers mounted in the same session. The model
+routes on the published metadata; that metadata is the entire contract.
+
+---
+
+## Rule-by-rule defense
+
+### MCP-001 — Tool has no description (Severity: low, Confidence: 0.9, Fix type: code)
+
+**What we detect:** an MCP tool registration whose Python handler has no
+docstring (predicate `has_docstring: false`). The docstring is the description
+MCP advertises to connecting clients.
+
+**Why it is flaggable:** with no published description, every connecting model
+loses the primary signal for deciding whether to call the tool, producing
+wrong-tool or skipped calls across all clients of the server. Confidence 0.9
+reflects that the absence is mechanical and certain; the residual gap is a tool
+that sets `description=` on the decorator instead of a docstring (captured in
+`Config`, not the docstring), which would false-positive — kept at low severity
+because the consequence is degraded routing, not a security failure.
+
+### MCP-002 — Tool has no type-annotated parameters (Severity: medium, Confidence: 0.85, Fix type: code)
+
+**What we detect:** a handler with parameters but no type annotations
+(`has_params: true` and `has_typed_params: false`).
+
+**Why it is flaggable:** MCP derives the published input JSON schema from the
+handler's type annotations. Without them the advertised schema is unconstrained,
+so connecting models send inputs the handler cannot rely on and runtime errors
+surface inside the server. Medium severity: degraded validation is a
+reliability and minor injection-surface concern, not a direct compromise.
+
+### MCP-003 — Ambiguous tool name (Severity: low, Confidence: 0.85, Fix type: code)
+
+**What we detect:** a tool named from a fixed ambiguous set (`process`,
+`handle`, `run`, `execute`, ...) via `name_in`.
+
+**Why it is flaggable:** an ambiguous name gives the model no intent signal and
+collides across servers in a shared session. Because an MCP server's consumers
+are not controlled by the author, the cost is paid everywhere it is mounted.
+
+### MCP-011 — TypeScript MCP tool has no description (Severity: low, Confidence: 0.85, Fix type: code)
+
+**What we detect:** a TypeScript `registerTool(name, {description, ...}, handler)`
+(or legacy `tool(...)`) whose `description` is missing or empty
+(`has_docstring: false`, reading the captured `Description`). A description built
+from a non-literal expression is captured as empty and also fires.
+
+**Why it is flaggable:** identical mechanism to MCP-001 on the TypeScript SDK —
+the registration config's `description` is the model's routing signal. Confidence
+0.85 (vs MCP-001's 0.9) reflects that the TypeScript capture can miss a
+description supplied through an unusual expression shape.
+
+---
+
+## What this policy does not cover
+
+Whether a present description is *accurate*, whether a typed schema is *correct*,
+and the low-level `Server` + `setRequestHandler` authoring shape (tools there are
+returned from a `ListTools` handler, not named at a registration call site, so no
+per-tool definition is extracted). Resource and prompt registrations
+(`@mcp.resource` / `@mcp.prompt`, `registerResource` / `registerPrompt`) are not
+yet discovered.


### PR DESCRIPTION
## Summary

Adds the rationale docs for the new `mcp` rule category, grounding the 14 MCP rules shipped in `trustabl/trustabl-rules#5`. Keeps `check_rulebook.py` clean.

## What changed
Eight rationale docs under `docs/Policy/mcp/` (one per `mcp/` YAML topic) covering:
- **Python MCP-001..010** and **TypeScript MCP-011..014**.

Each carries machine-checked front-matter (severity/confidence/scope matching the shipped YAML, OWASP LLM Top 10:2025 `references`, `fix_type`) and per-rule defense prose, cross-referencing the shared OpenAI/Claude threat models where the mechanism is identical and focusing on the MCP-specific angle: tools published across a trust boundary to whatever client/model connects.

No gate change was needed — categories are derived from the rules pack, not a fixed allowlist.

## Verification
`python tools/check_rulebook.py --rules-repo ../trustabl-rules` → **OK: 102 rules, 0 warnings** (was 14 errors for the undocumented MCP rules).
