### PR TITLE
fix(docs): repoint SSRF cross-references at the canonical doc

### DIFF
--- a/docs/Policy/langchain/ssrf.md
+++ b/docs/Policy/langchain/ssrf.md
@@ -25,7 +25,7 @@ references: [LLM06, LLM02]
 **Fix types:** code
 **References:** LLM06 (Excessive Agency), LLM02 (Sensitive Information Disclosure)
 
-> **Read [openai_sdk/ssrf.md](../openai_sdk/ssrf.md) for the full threat model.**
+> **Read [claude_sdk/ssrf.md](../claude_sdk/ssrf.md) for the full threat model.**
 > This document covers the LangChain-specific differences only.
 
 ---
@@ -43,7 +43,7 @@ a plain string literal. TypeScript (LC-013) reads the `dynamic_url` fact, set wh
 ## Why a model-controlled URL is server-side request forgery
 
 The mechanism and the metadata-endpoint / internal-service impact are covered in
-[openai_sdk/ssrf.md](../openai_sdk/ssrf.md). The LangChain-specific note: this
+[claude_sdk/ssrf.md](../claude_sdk/ssrf.md). The LangChain-specific note: this
 ecosystem ships a `RequestsToolkit` and a `Requests*` tool family whose docstrings
 explicitly require `allow_dangerous_requests=True` precisely because they hand the
 model an arbitrary-URL fetch. A hand-rolled `requests.get(url)` inside a `@tool`
@@ -96,4 +96,4 @@ Validate the URL against a host allow-list, reject private and link-local ranges
 (and redirects into them), and never pass a raw model-supplied URL to the HTTP
 client. If the tool talks to one service, hard-code the base URL and accept only a
 path/query from the model. The full safe pattern is in
-[openai_sdk/ssrf.md](../openai_sdk/ssrf.md#recommendations-beyond-the-fix).
+[claude_sdk/ssrf.md](../claude_sdk/ssrf.md#recommendations-beyond-the-fix).

--- a/docs/Policy/mcp/ssrf.md
+++ b/docs/Policy/mcp/ssrf.md
@@ -23,7 +23,7 @@ references: [LLM06, LLM02]
 **Rules:** MCP-008, MCP-013  
 **References:** LLM06 (Excessive Agency), LLM02 (Sensitive Information Disclosure)
 
-> Shares the SSRF threat model with [openai_sdk/ssrf.md](../openai_sdk/ssrf.md).
+> Shares the SSRF threat model with [claude_sdk/ssrf.md](../claude_sdk/ssrf.md).
 > MCP-specific angle only.
 
 ---


### PR DESCRIPTION
`langchain/ssrf.md` and `mcp/ssrf.md` both defer their threat model to `docs/Policy/openai_sdk/ssrf.md`. That file does not exist — OpenAI ships no `ssrf.yaml`, so its SSRF rules (OAI-018, OAI-024) are documented inside `openai_sdk/network.md`.

Four dead links, one of them anchored at a `#recommendations-beyond-the-fix` section the missing file could not provide. Repointed at `claude_sdk/ssrf.md`, the canonical full SSRF threat model — the same target `google_adk/ssrf.md` already uses, and it carries every anchor referenced.

Link-only change; both docs keep their SDK-specific angle.

Verified every relative `.md` link and `#anchor` under `docs/Policy/` resolves: 0 broken, down from 4.

Note: `check_rulebook.py` is currently red on `main` for OAI-112/PYD-106, which #25 fixes. Unrelated to this change.