### PR TITLE
docs(mcp): add missing recommendations section to path-safety policy

### DIFF
--- a/docs/Policy/mcp/path_safety.md
+++ b/docs/Policy/mcp/path_safety.md
@@ -59,3 +59,65 @@ Whether a given parameter is genuinely caller-controlled; containment performed
 by a helper in another module; symlink-escape after a correct `.resolve()`; and
 the TypeScript MCP path surface (no TS path-normalization predicate exists yet —
 TS filesystem risk is approximated only by the shell and code-exec rules).
+
+---
+
+## Recommendations beyond the fix
+
+```python
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("docs")
+
+# The root comes from the server's own configuration — never from a parameter.
+_ROOT = Path("/srv/agent-docs").resolve()
+
+
+def _contained(candidate: str) -> Path:
+    """Resolve candidate under _ROOT, or raise if it escapes."""
+    # An absolute candidate makes `/` discard _ROOT entirely; resolve() plus the
+    # containment check is what catches that, and traversal, and symlinks.
+    resolved = (_ROOT / candidate).resolve()
+    if not resolved.is_relative_to(_ROOT):
+        raise ValueError("path escapes the document root")
+    return resolved
+
+
+@mcp.tool()
+def read_doc(relative_path: str) -> dict:
+    """Read a UTF-8 document from the server's document root."""
+    try:
+        target = _contained(relative_path)
+    except ValueError:
+        return {"error": "path is outside the document root", "code": "forbidden",
+                "retryable": False}
+    if not target.is_file():
+        return {"error": "no such document", "code": "not_found", "retryable": False}
+    return {"content": target.read_text(encoding="utf-8", errors="replace")[:500_000]}
+```
+
+The traversal rationale is in
+[openai_sdk/path_safety.md](../openai_sdk/path_safety.md#recommendations-beyond-the-fix).
+MCP-specific additions:
+
+1. Take the root from server configuration, never from a second parameter. The
+   connecting client chooses every argument, so a `root=` parameter alongside a
+   `path=` parameter is not containment — it is a traversal with extra steps.
+2. Treat a client-advertised root as a narrowing, never a widening. MCP lets a
+   client tell the server where it believes work should happen; that is useful
+   for intersecting with the server's own root, and is not a grant. The server
+   is the party that owns its filesystem.
+3. Validate every path parameter, not the first one. MCP-005 is per-parameter
+   precisely because a handler that resolves `src` and forwards `dest`
+   untouched is still a traversal, and the resolved parameter makes the code
+   look careful.
+4. Compare with `is_relative_to`, not a string prefix. `/srv/agent-docs-evil`
+   passes `startswith("/srv/agent-docs")`.
+5. Remember that extracting the guard into a helper can stop the rule firing
+   without changing the risk — the predicate stops seeing the raw parameter
+   reach I/O. That is a reason to unit-test the helper against `..`, absolute
+   paths, and a symlink pointing out of the root, rather than to inline it.
+6. Bound the read. Containment decides *which* file the caller reaches; it says
+   nothing about a 4GB one.


### PR DESCRIPTION
Fourth of eight. Same gap as #27–#29.

`mcp/path_safety.md` (MCP-005) now closes with a FastMCP reader anchored to a configured root, using `resolve()` + `is_relative_to()`.

MCP-specific points:
- The root must come from server config, never a second parameter. The connecting client chooses every argument, so `root=` next to `path=` is a traversal with extra steps.
- A client-advertised root narrows, never widens — the server owns its filesystem.
- Validate *every* path parameter. MCP-005 is per-parameter because a handler that resolves `src` and forwards `dest` raw is still a traversal, and the resolved one makes the code look careful.
- Extracting the guard into a helper stops the predicate seeing the raw parameter reach I/O without changing the risk. Called out as a reason to unit-test the helper, not to inline it.

Checked the guard's behavior rather than asserting it — `../../etc/passwd` and `/etc/passwd` both rejected, `notes/a.md` and `ok/../ok2.md` accepted, and the documented `startswith` pitfall (`/srv/agent-docs-evil`) confirmed True. Sample parses under `ast.parse`.