### PR TITLE
docs(policy): add rationale for PYD-106 and OAI-112

### DIFF
--- a/docs/Policy/openai_sdk/agent_safety.md
+++ b/docs/Policy/openai_sdk/agent_safety.md
@@ -38,17 +38,22 @@ rules:
     confidence: 0.6
     scope: agent
     fix_type: config
-references: [LLM01, LLM06]
+  - id: OAI-112
+    severity: low
+    confidence: 0.6
+    scope: agent
+    fix_type: config
+references: [LLM01, LLM06, LLM10]
 ---
 
 # Policy Rationale: Agent Wiring Safety
 
 **Policy ID:** `openai_sdk_agent_safety`  
 **File:** `openai_sdk/agent_safety.yaml`  
-**Rules:** OAI-101, OAI-102, OAI-103, OAI-104, OAI-105, OAI-109, OAI-110  
-**Severities:** high, high, high, medium, high, high, medium  
-**Fix types:** config, config, config, config, config, config, config  
-**References:** LLM01, LLM06
+**Rules:** OAI-101, OAI-102, OAI-103, OAI-104, OAI-105, OAI-109, OAI-110, OAI-112  
+**Severities:** high, high, high, medium, high, high, medium, low  
+**Fix types:** config, config, config, config, config, config, config, config  
+**References:** LLM01 (Prompt Injection), LLM06 (Excessive Agency), LLM10 (Unbounded Consumption)
 
 ---
 
@@ -262,10 +267,49 @@ last line before the user/caller.
 are low-risk (public data, no sensitive egress), so the missing output guardrail is
 often acceptable — a review prompt more than a defect.
 
+### OAI-112 — Agent has no explicit max_turns limit (Severity: low, Confidence: 0.6, Fix type: config)
+
+**What we detect:** an agent that no `Runner.run` / `run_sync` / `run_streamed`
+call executes with a `max_turns=` argument (predicate
+`agent_run_call_max_turns_missing`). The rule is call-site scoped: it is the
+absence across every run of that agent that fires, not the constructor.
+
+**Why it is flaggable:** without an explicit cap the agent loop runs to whatever
+`DEFAULT_MAX_TURNS` the SDK applies, rather than to a bound sized for this task. A
+model that oscillates — retrying a failing tool, re-reading the same file,
+ping-ponging between two steps — keeps spending turns, tokens and tool side
+effects until that implicit ceiling is reached. The ceiling is also the SDK's to
+change: a version bump can move it with no change on your side. An explicit cap
+turns a stuck run into an observable `MaxTurnsExceeded` at a point you chose.
+
+**Real-world consequence:** a tool starts returning a malformed payload; the model
+re-calls it every turn trying to parse it, and the run exhausts the default turn
+budget. The symptom reaching the operator is latency and spend, not a bounded
+exception naming the tool that got stuck.
+
+**Why severity is low and not medium:** a default ceiling does exist, so the loop
+is unbounded relative to intent rather than genuinely unbounded, and a short
+single-lookup agent may never approach it. It stays above informational because
+the turns being spent can carry tool side effects, not only tokens. **Fix type —
+config:** the fix is a keyword argument at the call site, not a code change.
+**Confidence 0.6:** the rule sees only `Runner.*` call sites, so an agent bounded
+some other way — an external timeout, a wrapper that caps turns, an orchestrator
+that stops the run — is over-flagged.
+
+> Shares its threat model with
+> [pydantic_ai/agent_safety.md](../pydantic_ai/agent_safety.md)'s **PYD-106**:
+> both flag an agent run whose bound is left to a framework default rather than
+> sized for the task. The axis differs — the OpenAI Agents SDK applies a default
+> turn ceiling, Pydantic AI defaults to a request cap and leaves tokens open.
+
 ---
 
 ## What this policy does not cover
 
+- Whether a run is bounded outside the `Runner.*` call site — an external
+  timeout, an orchestrator turn budget, or a wrapper that injects `max_turns` is
+  invisible to OAI-112, and what a *sensible* cap would be for a given agent is
+  out of scope: it flags the absence of an explicit limit, not one set too high.
 - The *quality* of guardrails that are present — a no-op `input_guardrail` /
   `output_guardrail` satisfies OAI-101/106/109/110 without screening anything.
 - Shell/filesystem capability delivered via a `@function_tool` (a `KindOpenAITool`)

--- a/docs/Policy/pydantic_ai/agent_safety.md
+++ b/docs/Policy/pydantic_ai/agent_safety.md
@@ -23,6 +23,11 @@ rules:
     confidence: 0.7
     scope: agent
     fix_type: config
+  - id: PYD-106
+    severity: low
+    confidence: 0.6
+    scope: agent
+    fix_type: config
 references: [LLM05, LLM06, LLM10]
 ---
 
@@ -30,9 +35,9 @@ references: [LLM05, LLM06, LLM10]
 
 **Policy ID:** `pydantic_ai_agent_safety`  
 **File:** `pydantic_ai/agent_safety.yaml`  
-**Rules:** PYD-101, PYD-102, PYD-103, PYD-105  
-**Severities:** low, high, medium, low  
-**Fix types:** config, config, config, config  
+**Rules:** PYD-101, PYD-102, PYD-103, PYD-105, PYD-106  
+**Severities:** low, high, medium, low, low  
+**Fix types:** config, config, config, config, config  
 **References:** LLM05 (Improper Output Handling), LLM06 (Excessive Agency), LLM10 (Unbounded Consumption)
 
 ---
@@ -181,6 +186,40 @@ constructor change. **Confidence 0.7:** the rule cannot tell whether the agent's
 tools have side effects, so it over-flags exhaustive-mode agents whose tools are
 all read-only.
 
+### PYD-106 — Agent has no explicit usage_limits set (Severity: low, Confidence: 0.6, Fix type: config)
+
+**What we detect:** an agent that no `run` / `run_sync` / `run_stream` call
+executes with a `usage_limits=` argument (predicate
+`agent_run_call_usage_limits_missing`). The rule is call-site scoped: it is the
+absence across every run of that agent that fires, not the constructor.
+
+**Why it is flaggable:** with no explicit limit Pydantic AI falls back to a bare
+`UsageLimits()`, which caps request count and leaves token and cost usage
+unbounded. The default therefore bounds the wrong axis. A run can sit well inside
+the request cap while a long tool-calling chain, or a model that oscillates
+between two steps, spends far more tokens than the task warrants. An explicit,
+task-sized `UsageLimits` also converts a runaway run into a `UsageLimitExceeded`
+the caller can catch, instead of a cost overrun nobody observes until the bill.
+
+**Real-world consequence:** a summarization agent is handed a document far larger
+than expected; each request stays under the default request cap while the run
+consumes an order of magnitude more tokens than budgeted, and the overrun surfaces
+on an invoice rather than as a handled exception.
+
+**Why severity is low and not medium:** the request cap does bound the loop, so
+the exposure is spend and latency rather than a security or correctness failure,
+and a short agent over small inputs may never approach a limit worth setting.
+**Fix type — config:** the fix is a keyword argument at the call site, not a code
+change. **Confidence 0.6:** the rule sees only `run` / `run_sync` / `run_stream`
+call sites, so an agent bounded some other way — an external budget guard, a
+wrapper that injects limits, a caller-side timeout — is over-flagged.
+
+> Shares its threat model with
+> [openai_sdk/agent_safety.md](../openai_sdk/agent_safety.md)'s **OAI-112**: both
+> flag an agent run whose bound is left to a framework default rather than sized
+> for the task. The axis differs — Pydantic AI defaults to a request cap and
+> leaves tokens open, the OpenAI Agents SDK applies a default turn ceiling.
+
 ---
 
 ## What this policy does not cover
@@ -190,10 +229,12 @@ all read-only.
 - Hand-rolled URL fetches inside a tool body — caught by **PYD-005** (ssrf.md);
   PYD-103 covers only the native fetcher tools.
 - Whether the agent's prompt surface is actually reachable by untrusted content —
-  all four rules flag a configuration, not a proven injection path.
+  all five rules flag a configuration, not a proven injection path.
 - PYD-101 cannot tell whether a `str` output is consumed by code (risky) or only
   shown to a human (safe); PYD-105 cannot tell whether pending tools have side
-  effects.
+  effects; PYD-106 cannot tell whether a run is bounded outside the call site.
+- What a *sensible* usage limit would be for a given agent. PYD-106 flags the
+  absence of an explicit limit, not a limit that is set too high.
 - A native tool referenced under an alias, or a provider tool outside the listed
   class set, may escape the class-name match. Whether a native tool's execution or
   fetch environment is sandboxed is not visible to the match.


### PR DESCRIPTION

**Branch:** `docs/close-rationale-gaps-pyd106-oai112` · **Files:** 2 · **Lines:** +95 −10

### What

`tools/check_rulebook.py` fails on `main`:

```
rules pack: 206 rules from ../trustabl-rules
rationale docs: 85 (85 with front-matter)

ERROR rule OAI-112 (openai_sdk/agent_safety.yaml) has no rationale doc
      (expected one covering it under docs/Policy/openai_sdk/agent_safety.md)
ERROR rule PYD-106 (pydantic_ai/agent_safety.yaml) has no rationale doc
      (expected one covering it under docs/Policy/pydantic_ai/agent_safety.md)

FAILED: 2 error(s), 0 warning(s).
```

These are the only two of 206 shipped rules without a rationale section. This PR adds
both and turns the gate green.

### Why the two belong in one PR

Both are agent-scope, `low` / `0.6`, `fix_type: config`, and both describe the same
threat: an agent run whose bound is left to a framework default rather than sized for
the task. The axis differs — the OpenAI Agents SDK applies a default turn ceiling,
Pydantic AI defaults to a request cap and leaves token and cost usage open — so each
doc carries its own section plus a short cross-reference to the other, matching the
pattern already used between `mcp/tool_definition.md` and
`openai_sdk/tool_definition.md`.

### Changes

`docs/Policy/pydantic_ai/agent_safety.md`
- front-matter entry for PYD-106
- header `Rules` / `Severities` / `Fix types` extended
- PYD-106 rule-by-rule section in the existing format
- two limitation bullets, and "all four rules" corrected to "all five"

`docs/Policy/openai_sdk/agent_safety.md`
- front-matter entry for OAI-112
- header lines extended
- OAI-112 rule-by-rule section
- one limitation bullet
- **LLM10 (Unbounded Consumption)** added to the references. The existing
  LLM01/LLM06 pair does not cover an unbounded run loop; `pydantic_ai/agent_safety.md`
  already carries LLM10 for the same reason.

### Verification

```
$ python tools/check_rulebook.py --rules-repo ../trustabl-rules
rules pack: 206 rules
rationale docs: 85 (85 with front-matter)

OK: rulebook consistent (0 warning(s)).
```

### Deliberately out of scope

`tools/gen_index.py --check` already reports five stale index files on `main`:

```
STALE index files (run `python tools/gen_index.py`):
  POLICY_INDEX.md
  claude_sdk/POLICY_INDEX.md
  openai_sdk/POLICY_INDEX.md
  crewai/POLICY_INDEX.md
  pydantic_ai/POLICY_INDEX.md
```

That drift predates this change — regenerating on a clean checkout of `main` produces
a 410-line diff touching `claude_sdk` and `crewai`, which this PR cannot affect. It is
left for its own PR rather than mixed into a docs review. Happy to open that next if
you want it.

### One note on the hackathon page

`cohorts.algorithmacy.org/hackathon/trustabl` lists "completing 14 missing MCP rule
rationale documents" as the main contribution path. `docs/Policy/mcp/` now covers all
22 MCP rules, and a full sweep shows 204 of 206 rules documented — the two in this PR
were the only gaps. The page may be worth updating so contributors are not sent after
work that is already done.
