### PR TITLE
docs(mcp): add missing recommendations section to code-execution policy

### DIFF
--- a/docs/Policy/mcp/code_execution.md
+++ b/docs/Policy/mcp/code_execution.md
@@ -75,3 +75,78 @@ Whether the evaluated string is genuinely caller-influenced; indirect execution
 via `getattr`/`importlib`/`vm` module/`require` of attacker-named modules; and
 sandboxed evaluators that are still flagged because the rule keys on the call, not
 its safety.
+
+---
+
+## Recommendations beyond the fix
+
+The fix is not to sanitize the input to `eval` — it is to stop having an `eval`.
+Almost every handler that reaches for one wants a small, closed grammar, and
+that can be walked directly:
+
+```python
+import ast
+import operator
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("calc")
+
+# Deliberately no ast.Pow: 9**9**9 is a one-token denial of service that needs
+# no code execution at all.
+_OPS = {
+    ast.Add: operator.add, ast.Sub: operator.sub,
+    ast.Mult: operator.mul, ast.Div: operator.truediv,
+    ast.Mod: operator.mod, ast.USub: operator.neg,
+}
+
+
+def _reduce(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return node.value
+    if isinstance(node, ast.BinOp) and type(node.op) in _OPS:
+        return _OPS[type(node.op)](_reduce(node.left), _reduce(node.right))
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _OPS:
+        return _OPS[type(node.op)](_reduce(node.operand))
+    raise ValueError("unsupported expression")
+
+
+@mcp.tool()
+def calculate(expression: str) -> dict:
+    """Evaluate an arithmetic expression over numeric literals (+ - * / %)."""
+    try:
+        return {"result": _reduce(ast.parse(expression, mode="eval").body)}
+    except (SyntaxError, ValueError, ZeroDivisionError, OverflowError) as exc:
+        return {"error": str(exc), "code": "bad_expression", "retryable": False}
+```
+
+`__import__("os").system("id")` and `open("/etc/passwd").read()` both parse
+fine and are then rejected by the walk, because the walk enumerates what is
+allowed rather than guessing at what is dangerous.
+
+The dynamic-eval rationale is in
+[openai_sdk/code_execution.md](../openai_sdk/code_execution.md#recommendations-beyond-the-fix).
+MCP-specific additions:
+
+1. Enumerate the allowed node types; never blocklist the dangerous ones. Every
+   published `eval` sandbox that filtered on names — `__import__`, `__class__`,
+   dunder attributes — was escaped through a name its author had not thought
+   of. An allow-list fails closed against the payload nobody predicted.
+2. Size the blast radius by the *server*, not the tool. An in-process `eval` in
+   an SDK tool compromises that agent's process; an MCP server is shared
+   infrastructure, so the same call reaches the credentials, in-memory state,
+   and upstream connections belonging to every other tool on that server and
+   every client currently connected to it.
+3. If you genuinely need to run caller-supplied code, make it a service rather
+   than a handler: a separate process or container, no network, a memory and
+   CPU cap, and a wall-clock kill. A handler cannot be made safe by argument
+   inspection, and MCP-009 will keep firing on it — correctly.
+4. Bound the grammar for cost, not just for safety. Exponentiation, deep
+   recursion, and large literal repetition burn CPU inside the server process
+   without executing anything the rule would call code, and a stalled worker
+   is the same outcome as an unbounded network call
+   ([network.md](network.md)).
+5. On the TypeScript side (MCP-014) remember `new Function` is the same
+   primitive as `eval` and is often reached for as though it were milder.
+   Neither the `vm` module nor `require` of a caller-named module is matched by
+   this rule, and both execute in-process just as thoroughly.


### PR DESCRIPTION
Sixth of eight. Same gap as #27–#32.

`mcp/code_execution.md` (MCP-009, MCP-014) now closes with the *replacement* for `eval` rather than advice on hardening one — a closed-grammar AST walk that enumerates permitted node types.

Ran the sample before documenting it:

| input | result |
|---|---|
| `2 + 3 * 4` | `14` |
| `-(7 % 4)` | `-3` |
| `1/0` | structured `bad_expression` |
| `__import__("os").system("id")` | rejected |
| `open("/etc/passwd").read()` | rejected |
| `9**9**9` | rejected — `ast.Pow` deliberately omitted |

That last one is the point of the fourth recommendation: `9**9**9` stalls the worker without executing anything the rule would call code, so the grammar gets bounded for cost as well as safety.

MCP-specific framing is blast radius — an in-process `eval` in an SDK tool compromises that agent's process, while an MCP server is shared infrastructure reaching every other tool on it and every connected client.