### PR TITLE
fix(tools): make the book assemble outside CI

### DIFF
--- a/tools/build_book.py
+++ b/tools/build_book.py
@@ -131,8 +131,18 @@ def main() -> int:
 
     out = repo / args.out
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(build(repo, rules_repo), encoding="utf-8", newline="\n")
-    print(f"wrote {out.relative_to(repo)}")
+    # write_bytes (not write_text(newline=...)) keeps the output LF on every
+    # platform AND runs on Python 3.9 — write_text's newline kwarg is 3.10+,
+    # which crashes assembly under the repo's default python3. Same reasoning
+    # as gen_index.py.
+    out.write_bytes(build(repo, rules_repo).encode("utf-8"))
+    # A path outside the repo has no relative form; report it as given rather
+    # than raising after the file has already been written.
+    try:
+        shown = out.relative_to(repo)
+    except ValueError:
+        shown = out
+    print(f"wrote {shown}")
     return 0
 
 


### PR DESCRIPTION
Two bugs on adjacent lines in `build_book.py`, both invisible to CI, both hit on the first local run of the workflow `tools/README.md` recommends ("The assemble step needs only python + pyyaml").

**1. `make assemble` / `make book` die before writing anything.**
```
$ python3 tools/build_book.py --rules-repo ../trustabl-rules --out build/trustabl-rulebook.md
TypeError: write_text() got an unexpected keyword argument 'newline'
```
`Path.write_text(..., newline=...)` is Python 3.10+; the macOS system python3 is 3.9.6. **`gen_index.py` already solved this**, and its comment names the same failure:

> `write_bytes` (not `write_text(newline=...)`) keeps the output LF on every platform AND runs on Python 3.9 — write_text's newline kwarg is 3.10+, which crashed regeneration under the repo's default python3.

`build_book.py` never got the same treatment. Applies it, with LF preserved (no CR bytes in the output).

**2. A successful build reports failure.** The success message called `out.relative_to(repo)`, which raises for any `--out` outside the repo — after the file has been written:

```
$ python3 tools/build_book.py --out /tmp/x.md ...
ValueError: '/tmp/x.md' is not in the subpath of '.../trustabl-rulebook'
$ ls -la /tmp/x.md
-rw-r--r--  559036 ...        # written fine
```

Exit code said failure; the artifact was correct. Now reports the path as given:
```
wrote /tmp/x.md            exit=0
wrote build/trustabl-rulebook.md   exit=0    # in-repo output unchanged
```

CI runs 3.12 and always writes inside the repo, so neither path was ever exercised there.

(Noted, not changed: `tools/README.md` says "python 3.11+" while `gen_index.py` deliberately supports 3.9 — settled separately in #54, which depends on this PR.)