### PR TITLE
feat(tools): gate the rationale-doc sections the template requires

### DIFF
--- a/tools/check_rulebook.py
+++ b/tools/check_rulebook.py
@@ -6,7 +6,7 @@ rulebook's per-policy rationale docs. This is the rulebook analog of the
 engine's `TestPolicyRules_AllRulesCovered` guard: it fails CI when the book
 drifts from the rules users actually receive.
 
-It enforces three things:
+It enforces four things:
 
   1. COVERAGE   — every rule in trustabl-rules has a rationale doc covering it.
   2. CONSISTENCY — each doc's front-matter (severity / confidence / scope) matches
@@ -15,6 +15,9 @@ It enforces three things:
   3. PLACEMENT  — a rule is documented in the chapter (category/topic) where it
                    actually lives, and docs do not reference rules that no longer
                    exist.
+  4. STRUCTURE  — every doc carries the sections the template guide requires. A
+                   doc that stops before "Recommendations beyond the fix" tells a
+                   reader what is wrong but not what to do instead.
 
 Front-matter shape expected on each `docs/Policy/<category>/<topic>.md` (see
 docs/policy-rationale-doc-template-guide.md):
@@ -59,6 +62,18 @@ except ImportError:
     sys.exit("error: pyyaml is required (pip install pyyaml)")
 
 CONFIDENCE_TOLERANCE = 1e-9
+
+# Level-2 headings every rationale doc must carry. The template guide
+# (docs/policy-rationale-doc-template-guide.md) says "Fill every section. Delete
+# no sections."; this is that instruction made checkable. Prose headings that
+# vary per doc — the "Why <topic> is a distinct concern" section — are not
+# listed, because their wording is deliberately per-topic.
+REQUIRED_SECTIONS = [
+    "What this policy covers",
+    "Rule-by-rule defense",
+    "What this policy does not cover",
+    "Recommendations beyond the fix",
+]
 VALID_FIX_TYPES = {"config", "code"}
 HINT_ID_RE = re.compile(r"^HINT-\d{4}$")
 
@@ -96,6 +111,7 @@ class DocRule:
 class RationaleDoc:
     path: Path
     has_front_matter: bool
+    body: str = ""
     policy_id: str | None = None
     category: str | None = None
     topic: str | None = None
@@ -182,7 +198,7 @@ def load_docs(rulebook_repo: Path) -> list[RationaleDoc]:
         text = md_path.read_text(encoding="utf-8")
         fm = parse_front_matter(text)
         if fm is None:
-            docs.append(RationaleDoc(path=md_path, has_front_matter=False))
+            docs.append(RationaleDoc(path=md_path, has_front_matter=False, body=text))
             continue
         doc_rules = []
         for r in fm.get("rules") or []:
@@ -203,6 +219,7 @@ def load_docs(rulebook_repo: Path) -> list[RationaleDoc]:
             RationaleDoc(
                 path=md_path,
                 has_front_matter=True,
+                body=text,
                 policy_id=fm.get("policy_id"),
                 category=fm.get("category"),
                 topic=fm.get("topic"),
@@ -233,6 +250,16 @@ def check(
             msg = f"{rel}: no YAML front-matter (cannot be machine-checked)"
             (errors if strict else warnings).append(msg)
             continue
+
+        # STRUCTURE
+        # Prefix match, not equality: a doc may qualify a heading it still
+        # carries — claude_skill/skill_safety.md uses "## What this policy does
+        # not cover (v1)" — and that is an editorial note, not a missing
+        # section.
+        headings = re.findall(r"^##\s+(.+?)\s*$", doc.body, re.MULTILINE)
+        for section in REQUIRED_SECTIONS:
+            if not any(h.startswith(section) for h in headings):
+                errors.append(f"{rel}: missing required section \"## {section}\"")
 
         for dr in doc.rules:
             rid = dr.rule_id


### PR DESCRIPTION
The template guide says **"Fill every section. Delete no sections."** and nothing checked it. That is how all eight `mcp/` docs shipped without *Recommendations beyond the fix* (#27–#36) while CI stayed green — the family told readers what was wrong and not what to write instead.

Adds **STRUCTURE** as a fourth check beside coverage, consistency, and placement.

**On `main` today** it reports exactly the eight known-bad docs:
```
ERROR docs/Policy/mcp/code_execution.md: missing required section "## Recommendations beyond the fix"
... (8 total, all mcp/)
```

**With #27–#36 merged** (verified against a local merge of all eight branches) the structure check reports **zero** errors — the only failures left are OAI-112/PYD-106, which #25 fixes.

Two deliberate choices:
- The per-topic *"Why &lt;topic&gt; is a distinct concern"* heading is **not** required. Its wording varies by design, and requiring it would either force a bland title or invite a stub.
- Headings match by **prefix, not equality**. My first cut used equality and flagged `claude_skill/skill_safety.md`, which heads its section *"What this policy does not cover (v1)"*. That is an editorial note on a section that is present — the doc was right and the gate was wrong.

⚠️ **Merge after #27–#36**, or CI here goes red on the gaps those PRs fill.