### PR TITLE
docs(template): say where the rule YAML actually lives

### DIFF
--- a/docs/policy-rationale-doc-template-guide.md
+++ b/docs/policy-rationale-doc-template-guide.md
@@ -1,12 +1,18 @@
 # Policy Rationale Doc — Template Guide
 
-Every policy YAML file in this repository requires a paired rationale document at:
+Every policy YAML file in
+[trustabl-rules](https://github.com/trustabl/trustabl-rules) requires a paired
+rationale document, and that document lives *here* at:
 
 ```
 docs/Policy/<category>/<topic>.md
 ```
 
-Mirror the YAML directory structure exactly. Create the `.md` at the same time as the YAML — never retroactively.
+This repo holds no rule YAML — a rule spans two repositories, and the pairing is
+what keeps them in step. Mirror the pack's directory structure exactly:
+`<category>/<topic>.yaml` there becomes `docs/Policy/<category>/<topic>.md`
+here. Write the `.md` as part of the same change as the YAML — never
+retroactively.
 
 ---
 


### PR DESCRIPTION
The template guide's first line reads:

> Every policy YAML file **in this repository** requires a paired rationale document at: `docs/Policy/<category>/<topic>.md`

This repository holds no rule YAML. The README says so directly, two sections later: *"This repo is documentation only — it contains no rule YAML."* The pack lives in `trustabl-rules`.

Someone following the guide from its first line goes looking for a YAML tree that is not here. Names the pack, says the rationale doc lives here, and spells out the mapping: `<category>/<topic>.yaml` there → `docs/Policy/<category>/<topic>.md` here.

Also checked and deliberately **not** changed: `../claude_sdk/path_safety.md` in the cross-referencing example does not resolve from `docs/`, but that snippet is illustrating a link written *from inside a policy doc*, where it is correct.