### PR TITLE
feat(tools): check the rendered rule heading against the pack

### DIFF
--- a/tools/check_rulebook.py
+++ b/tools/check_rulebook.py
@@ -6,7 +6,7 @@ rulebook's per-policy rationale docs. This is the rulebook analog of the
 engine's `TestPolicyRules_AllRulesCovered` guard: it fails CI when the book
 drifts from the rules users actually receive.
 
-It enforces three things:
+It enforces four things:
 
   1. COVERAGE   — every rule in trustabl-rules has a rationale doc covering it.
   2. CONSISTENCY — each doc's front-matter (severity / confidence / scope) matches
@@ -15,6 +15,9 @@ It enforces three things:
   3. PLACEMENT  — a rule is documented in the chapter (category/topic) where it
                    actually lives, and docs do not reference rules that no longer
                    exist.
+  4. STRUCTURE  — every doc carries the sections the template guide requires. A
+                   doc that stops before "Recommendations beyond the fix" tells a
+                   reader what is wrong but not what to do instead.
 
 Front-matter shape expected on each `docs/Policy/<category>/<topic>.md` (see
 docs/policy-rationale-doc-template-guide.md):
@@ -59,6 +62,18 @@ except ImportError:
     sys.exit("error: pyyaml is required (pip install pyyaml)")
 
 CONFIDENCE_TOLERANCE = 1e-9
+
+# Level-2 headings every rationale doc must carry. The template guide
+# (docs/policy-rationale-doc-template-guide.md) says "Fill every section. Delete
+# no sections."; this is that instruction made checkable. Prose headings that
+# vary per doc — the "Why <topic> is a distinct concern" section — are not
+# listed, because their wording is deliberately per-topic.
+REQUIRED_SECTIONS = [
+    "What this policy covers",
+    "Rule-by-rule defense",
+    "What this policy does not cover",
+    "Recommendations beyond the fix",
+]
 VALID_FIX_TYPES = {"config", "code"}
 HINT_ID_RE = re.compile(r"^HINT-\d{4}$")
 
@@ -96,6 +111,7 @@ class DocRule:
 class RationaleDoc:
     path: Path
     has_front_matter: bool
+    body: str = ""
     policy_id: str | None = None
     category: str | None = None
     topic: str | None = None
@@ -182,7 +198,7 @@ def load_docs(rulebook_repo: Path) -> list[RationaleDoc]:
         text = md_path.read_text(encoding="utf-8")
         fm = parse_front_matter(text)
         if fm is None:
-            docs.append(RationaleDoc(path=md_path, has_front_matter=False))
+            docs.append(RationaleDoc(path=md_path, has_front_matter=False, body=text))
             continue
         doc_rules = []
         for r in fm.get("rules") or []:
@@ -203,6 +219,7 @@ def load_docs(rulebook_repo: Path) -> list[RationaleDoc]:
             RationaleDoc(
                 path=md_path,
                 has_front_matter=True,
+                body=text,
                 policy_id=fm.get("policy_id"),
                 category=fm.get("category"),
                 topic=fm.get("topic"),
@@ -233,6 +250,16 @@ def check(
             msg = f"{rel}: no YAML front-matter (cannot be machine-checked)"
             (errors if strict else warnings).append(msg)
             continue
+
+        # STRUCTURE
+        # Prefix match, not equality: a doc may qualify a heading it still
+        # carries — claude_skill/skill_safety.md uses "## What this policy does
+        # not cover (v1)" — and that is an editorial note, not a missing
+        # section.
+        headings = re.findall(r"^##\s+(.+?)\s*$", doc.body, re.MULTILINE)
+        for section in REQUIRED_SECTIONS:
+            if not any(h.startswith(section) for h in headings):
+                errors.append(f"{rel}: missing required section \"## {section}\"")
 
         for dr in doc.rules:
             rid = dr.rule_id

--- a/tools/check_rulebook.py
+++ b/tools/check_rulebook.py
@@ -10,8 +10,9 @@ It enforces four things:
 
   1. COVERAGE   — every rule in trustabl-rules has a rationale doc covering it.
   2. CONSISTENCY — each doc's front-matter (severity / confidence / scope) matches
-                   the rule's YAML. The book may not claim a severity the engine
-                   does not ship.
+                   the rule's YAML, and so does the per-rule heading a reader
+                   sees. The book may not claim a severity the engine does not
+                   ship, in either copy.
   3. PLACEMENT  — a rule is documented in the chapter (category/topic) where it
                    actually lives, and docs do not reference rules that no longer
                    exist.
@@ -297,6 +298,30 @@ def check(
                     f"{rel}: {rid} documented under topic {doc.topic!r} "
                     f"but the rule lives in {spec.topic!r} ({spec.source})"
                 )
+
+            # CONSISTENCY (rendered) — the per-rule heading a reader actually
+            # sees must agree with the pack too. The front-matter check above
+            # covers the machine-readable copy; this covers the human-readable
+            # one, which is what ends up in the PDF.
+            heading = re.search(
+                r"^###\s+" + re.escape(rid) + r"\s*[\u2014-]\s*.*?\(([^)]*)\)\s*$",
+                doc.body,
+                re.MULTILINE,
+            )
+            if heading:
+                meta = heading.group(1)
+                h_sev = re.search(r"Severity:\s*([A-Za-z]+)", meta)
+                h_conf = re.search(r"Confidence:\s*([0-9.]+)", meta)
+                if h_sev and h_sev.group(1).lower() != spec.severity:
+                    errors.append(
+                        f"{rel}: {rid} heading says severity "
+                        f"{h_sev.group(1).lower()!r} but the pack ships {spec.severity!r}"
+                    )
+                if h_conf and abs(float(h_conf.group(1)) - spec.confidence) > CONFIDENCE_TOLERANCE:
+                    errors.append(
+                        f"{rel}: {rid} heading says confidence "
+                        f"{h_conf.group(1)} but the pack ships {spec.confidence}"
+                    )
 
             # editorial field validation
             if dr.fix_type is not None and dr.fix_type not in VALID_FIX_TYPES:


### PR DESCRIPTION
⚠️ **Stacked on #42** — it contains that PR's commit and adds one on top. Merge #42 first and this reduces to a single commit. (#42 adds the `body` field on `RationaleDoc`; this check reads it.)

CONSISTENCY compares the pack against front-matter only. But every doc states severity and confidence **a second time**, in the per-rule heading:

```
### AG2-012 — Tool network call has no timeout (Severity: high, Confidence: 0.85, Fix type: code)
```

That is the copy a reader sees and the copy that ends up in the PDF, and nothing checked it. A recalibration that updates front-matter and misses a heading leaves the book asserting a severity the engine does not ship — with a green gate. The repo has recalibrated severities at least twice (#9, #18), so this is a path that has already been walked.

**All 204 headings agree with the pack today**, so this lands clean and holds the line rather than asking anyone to fix anything.

**Verified by mutation, not by absence of output.** Claiming `medium` / `0.5` for AG2-012 (ships `high` / `0.85`):

```
ERROR docs/Policy/autogen/network.md: AG2-012 heading says severity 'medium' but the pack ships 'high'
ERROR docs/Policy/autogen/network.md: AG2-012 heading says confidence 0.5 but the pack ships 0.85
```

Restoring the heading clears both.

The heading pattern tolerates the em-dash and hyphen forms both in use, and matches rule IDs containing digits (`AG2-`) — my first cut used `[A-Z]+-\d+` and silently skipped all 12 AutoGen rules.