### PR TITLE
docs: add rationale docs for LC-007, CREW-007, AG2-013, PYD-008

### DIFF
--- a/docs/Policy/autogen/error_handling.md
+++ b/docs/Policy/autogen/error_handling.md
@@ -1,0 +1,155 @@
+---
+policy_id: autogen_error_handling
+category: autogen
+topic: error_handling
+rules:
+  - id: AG2-013
+    severity: low
+    confidence: 0.6
+    scope: tool
+    fix_type: code
+references: [LLM05]
+---
+
+# Policy Rationale: AutoGen Error Contract Hygiene
+
+**Policy ID:** `autogen_error_handling`  
+**File:** `autogen/error_handling.yaml`  
+**Rules:** AG2-013  
+**Severities:** low  
+**Fix types:** code  
+**References:** LLM05 (Improper Output Handling)
+
+> Shares the structured-error threat model with
+> [openai_sdk/error_handling.md](../openai_sdk/error_handling.md). AutoGen-specific
+> angle only.
+
+---
+
+## What this policy covers
+
+An AutoGen / AG2 tool — a function registered with `register_function`,
+`register_for_llm` / `register_for_execution`, or an equivalent binding — whose
+body contains a `raise` and no `try`/`except`, detected by
+`all: [has_raise: true, has_try_except: false]`.
+
+---
+
+## Why error handling is a distinct concern in agent tools
+
+AutoGen's unit of state is the conversation. A tool's return value does not go
+to a caller that inspects it and discards it; it becomes a tool-response message
+appended to the chat history, and that history is re-sent to the model on every
+subsequent turn. An uncaught exception therefore does not fail once. It is
+stringified into a message that persists, and every later turn pays for it in
+context.
+
+That persistence is what distinguishes the AutoGen case. In a
+request/response tool loop a bad error string costs one turn's confusion. Here it
+is replayed for the remainder of the run, and in a group chat it is broadcast:
+`GroupChatManager` sends the shared transcript to each participant when selecting
+and prompting the next speaker, so one tool's traceback is read by every agent in
+the chat, on every round, whether or not it is relevant to them. A single verbose
+Python traceback in a five-agent chat is re-tokenized dozens of times before the
+run ends. The failure mode is not only that the model cannot recover — it is that
+the record of the failure crowds out the context needed to do anything else.
+
+Recovery is degraded in the ordinary way as well: the message carries no field
+separating a malformed argument from an unreachable dependency, so the model
+re-calls the tool identically, or hands the failure to another agent as prose,
+which does not have the call site either. And because the stringified exception
+is permanent chat state, any path, hostname or connection string in `str(e)` is
+carried into every participant's context and into the exported transcript
+(improper output handling, LLM05).
+
+---
+
+## Rule-by-rule defense
+
+### AG2-013 — AutoGen tool raises exceptions without a structured error contract (Severity: low, Confidence: 0.6, Fix type: code)
+
+**What we detect:**  
+A tool function body containing at least one `raise` statement and no
+`try`/`except` block anywhere in that body.
+
+**Why it is flaggable:**  
+Every failure the function can produce leaves it as an exception, so the
+tool-response message that lands in the conversation is a stringified traceback.
+The model has no field to branch on, and the bad message is now durable state.
+
+**Real-world consequence:**
+
+- A `load_profile` tool raises `KeyError` on an unknown name. The assistant sees
+  `KeyError: 'jdoe'`, re-calls with `jdoe`, and both the failure and the retry
+  stay in history — re-sent on every following turn for the rest of the run.
+- In a five-agent `GroupChat`, a tool raising a full `sqlalchemy` traceback puts
+  that traceback in the shared transcript. The manager includes it when prompting
+  each speaker, so it is re-read on every round by agents with no relation to the
+  tool.
+- A tool raising `FileNotFoundError` leaks the absolute path of a server-side
+  file into the permanent transcript, which is then exported for evaluation.
+
+**Why severity is low and not medium:**  
+The impact is degraded recovery and context waste plus an incidental disclosure
+channel; it grants no capability and crosses no privilege boundary. A raise is
+often deliberate, with the executor agent or a wrapping frame expected to
+structure it. Low matches the equivalent rules in the Claude, OpenAI, ADK and MCP
+packs.
+
+**Fix type — code:**  
+Returning `{"error": ..., "retryable": ...}` instead of raising is a source edit
+to the registered function.
+
+**Confidence 0.6:**  
+The check is body-local. False positives: a function that raises because a
+decorator or the executor agent converts the exception into the structured shape
+the rule asks for. False negatives: a `try`/`except` that catches and re-raises,
+or returns a bare string, satisfies the predicate while providing no contract.
+0.6 reflects a single-frame syntactic check standing in for a whole-call-path
+property.
+
+---
+
+## What this policy does not cover
+
+- Exception handling by a wrapping frame — a decorator, or the executor agent's
+  own handling — outside the tool body.
+- A `try`/`except` that catches and re-raises, or returns an unstructured string.
+- Whether the structured error is correct, or whether `retryable` reflects
+  reality.
+- Whether the message actually contains sensitive data.
+- Context growth from successful tool responses; the rule addresses the error
+  path only.
+
+---
+
+## Recommendations beyond the fix
+
+```python
+from autogen import register_function
+
+
+def load_profile(name: str) -> dict:
+    """Load a profile by name."""
+    try:
+        return {"ok": True, "profile": PROFILES[name]}
+    except KeyError:
+        return {"ok": False, "error": "no profile with that name", "retryable": False}
+    except TimeoutError:
+        return {"ok": False, "error": "profile service timed out", "retryable": True}
+
+
+register_function(load_profile, caller=assistant, executor=user_proxy,
+                  description="Load a profile by name.")
+```
+
+1. Return a `retryable` field on every failure path, so the next speaker can tell a
+   bad argument from a transient outage.
+2. Keep error payloads short. The tool response becomes permanent conversation
+   state, re-sent on every later turn — a full traceback is a recurring context
+   cost, not a one-off. A single-sentence message beats a stack dump.
+3. In a `GroupChat`, remember the transcript reaches every participant when the
+   manager prompts the next speaker. Write the error so an agent unrelated to the
+   tool can skip past it.
+4. Never pass a raw `str(e)` from a database or filesystem client through; it lands
+   in the exported transcript.

--- a/docs/Policy/crewai/error_handling.md
+++ b/docs/Policy/crewai/error_handling.md
@@ -1,0 +1,150 @@
+---
+policy_id: crewai_error_handling
+category: crewai
+topic: error_handling
+rules:
+  - id: CREW-007
+    severity: low
+    confidence: 0.6
+    scope: tool
+    fix_type: code
+references: [LLM05]
+---
+
+# Policy Rationale: CrewAI Error Contract Hygiene
+
+**Policy ID:** `crewai_error_handling`  
+**File:** `crewai/error_handling.yaml`  
+**Rules:** CREW-007  
+**Severities:** low  
+**Fix types:** code  
+**References:** LLM05 (Improper Output Handling)
+
+> Shares the structured-error threat model with
+> [openai_sdk/error_handling.md](../openai_sdk/error_handling.md). CrewAI-specific
+> angle only.
+
+---
+
+## What this policy covers
+
+A CrewAI tool — a `@tool`-decorated function or a `BaseTool` `_run` body — that
+contains a `raise` and no `try`/`except`, detected by
+`all: [has_raise: true, has_try_except: false]`.
+
+---
+
+## Why error handling is a distinct concern in agent tools
+
+CrewAI's executor catches a tool exception and returns its text into the agent's
+scratchpad as the observation for that step. The model then reasons over a
+sentence, not a status. It cannot separate "the argument was wrong" from "the
+remote timed out" from "you lack permission", and its default recovery for an
+undifferentiated failure is to repeat the call. Because CrewAI bounds an agent by
+`max_iter` rather than by any notion of progress, that repetition consumes the
+entire budget: the agent retries an unfixable call until the limit stops it, and
+the task ends with no result and a full bill.
+
+Delegation is what makes CrewAI's version of this worse than the single-agent
+case. A crew's agents pass work to each other, and a delegating agent reads the
+delegate's output as its own observation. An opaque error does not stay local to
+the task that produced it — it becomes the text a second agent reasons over, and
+that agent has strictly less context for interpreting it than the first. A
+`KeyError: 'ACME-2231'` that at least sat next to the failing call in agent A's
+scratchpad reaches agent B as a bare string with no call site attached. Failures
+therefore degrade as they propagate through the crew rather than being handled at
+the boundary where the information existed.
+
+The stringified exception is also a disclosure channel. `str(e)` from a database
+or filesystem error carries paths, hostnames and connection strings, and in a
+crew that text is copied into every downstream agent's context and into the run
+transcript (improper output handling, LLM05).
+
+---
+
+## Rule-by-rule defense
+
+### CREW-007 — CrewAI tool raises exceptions without a structured error contract (Severity: low, Confidence: 0.6, Fix type: code)
+
+**What we detect:**  
+A tool function body containing at least one `raise` statement and no
+`try`/`except` block anywhere in that body.
+
+**Why it is flaggable:**  
+Every failure the function can produce leaves it as an exception, so the
+observation the executor writes into the scratchpad is a stringified traceback.
+The tool exposes no field the model — or a delegating agent — can branch on.
+
+**Real-world consequence:**
+
+- A `fetch_invoice` tool raises `KeyError` on an unknown id. The researcher agent
+  sees `KeyError: 'INV-88213'`, cannot tell the id was wrong rather than the
+  service broken, and re-issues the identical call until `max_iter` ends the task.
+- A delegated `lookup_vendor` raises a `requests.ConnectionError`. The delegating
+  agent receives the connection string embedded in the message as its observation
+  and incorporates it into its own summary.
+- A tool raising on a transient timeout gives the model no `retryable` signal, so
+  a failure that a single retry would have cleared is reported to the crew as a
+  hard failure.
+
+**Why severity is low and not medium:**  
+The impact is degraded recovery plus an incidental disclosure channel; it grants
+no capability and crosses no privilege boundary. A raise is also often deliberate,
+with a wrapping frame or a `BaseTool` subclass expected to structure it. Low
+matches the severity of the equivalent rules in the Claude, OpenAI, ADK and MCP
+packs.
+
+**Fix type — code:**  
+Returning `{"error": ..., "retryable": ...}` instead of raising is a source edit
+to the tool body.
+
+**Confidence 0.6:**  
+The check is body-local. False positives: a tool that raises because a decorator
+or a `BaseTool` wrapper converts the exception into the structured shape the rule
+asks for. False negatives: a `try`/`except` that catches and re-raises, or that
+returns a bare string, satisfies the predicate while providing no contract. 0.6
+reflects a single-frame syntactic check standing in for a whole-call-path
+property.
+
+---
+
+## What this policy does not cover
+
+- Exception handling by a wrapping frame — a decorator, a `BaseTool` subclass, or
+  a crew-level error handler — outside the tool body.
+- A `try`/`except` that catches and re-raises, or returns an unstructured string.
+- Whether the structured error is correct: that `retryable` reflects reality, or
+  that the message names what the model should change.
+- Whether the message actually contains sensitive data.
+- How a delegating agent interprets a well-formed structured error; the rule
+  checks that one exists, not that the crew uses it well.
+
+---
+
+## Recommendations beyond the fix
+
+```python
+from crewai.tools import tool
+
+
+@tool("fetch_invoice")
+def fetch_invoice(invoice_id: str) -> dict:
+    """Fetch an invoice by id."""
+    try:
+        return {"ok": True, "invoice": INVOICES[invoice_id]}
+    except KeyError:
+        return {"ok": False, "error": "no invoice with that id", "retryable": False}
+    except TimeoutError:
+        return {"ok": False, "error": "billing service timed out", "retryable": True}
+```
+
+1. Return a `retryable` field on every failure path. Without it an agent spends its
+   whole `max_iter` budget re-issuing a call that cannot succeed.
+2. Write the error for the *next* reader, not the current one. In a crew the string
+   is also read by a delegating agent that never saw the call site, so it must name
+   the tool and the offending input itself.
+3. Keep failures local: handle them in the tool that produced them rather than
+   letting an opaque string propagate through delegation, where each hop loses
+   context.
+4. Never pass a raw `str(e)` from a database or filesystem client through; in a crew
+   it is copied into every downstream agent's context.

--- a/docs/Policy/langchain/error_handling.md
+++ b/docs/Policy/langchain/error_handling.md
@@ -1,0 +1,158 @@
+---
+policy_id: langchain_error_handling
+category: langchain
+topic: error_handling
+rules:
+  - id: LC-007
+    severity: low
+    confidence: 0.6
+    scope: tool
+    fix_type: code
+references: [LLM05]
+---
+
+# Policy Rationale: LangChain Error Contract Hygiene
+
+**Policy ID:** `langchain_error_handling`  
+**File:** `langchain/error_handling.yaml`  
+**Rules:** LC-007  
+**Severities:** low  
+**Fix types:** code  
+**References:** LLM05 (Improper Output Handling)
+
+> Shares the structured-error threat model with
+> [openai_sdk/error_handling.md](../openai_sdk/error_handling.md). LangChain-specific
+> angle only.
+
+---
+
+## What this policy covers
+
+A LangChain / LangGraph tool — a `@tool`-decorated function, or the function
+wrapped by `StructuredTool` / `Tool` — whose body contains a `raise` and no
+`try`/`except`, detected by `all: [has_raise: true, has_try_except: false]`.
+
+---
+
+## Why error handling is a distinct concern in agent tools
+
+A conventional caller reads an exception type. A model reads a string. That is
+the whole difference, and it is what makes an uncaught raise a reliability
+defect rather than a style choice.
+
+LangChain gives the raise two possible destinations, and neither carries
+structure. With the executor's default behavior the exception propagates and the
+run aborts, so a recoverable failure — a 404, a malformed argument the model
+could have corrected — ends the agent. With `handle_tool_error` set, the executor
+catches it and stringifies it into a `ToolMessage`, which the model reads as
+prose alongside every other message. There is no field distinguishing "you passed
+a bad argument, fix it" from "the remote is down, wait" from "you are not
+permitted, stop". The model's most common response to an undifferentiated failure
+string is to call the tool again with the same arguments, which produces the same
+string, until `max_iterations` ends the loop. The cost is the whole iteration
+budget spent on a failure that one structured field would have resolved on the
+second call.
+
+The stringified exception is also a disclosure channel. `str(e)` on a filesystem
+or database error routinely carries absolute paths, hostnames, connection strings
+and query fragments. In a conventional service that text lands in a log with an
+access control on it. Here it lands in the model's context, and from there in the
+transcript, any trace exporter attached to the run, and any surface that renders
+the conversation to a user (improper output handling, LLM05).
+
+---
+
+## Rule-by-rule defense
+
+### LC-007 — LangChain tool raises exceptions without a structured error contract (Severity: low, Confidence: 0.6, Fix type: code)
+
+**What we detect:**  
+A tool function body containing at least one `raise` statement and no
+`try`/`except` block anywhere in that body.
+
+**Why it is flaggable:**  
+The presence of a `raise` with no local handler means every failure this
+function can produce leaves it as an exception. Whatever the executor does next
+— abort, or stringify into a `ToolMessage` — the model receives no field it can
+branch on. The tool has no error contract; it has an error side effect.
+
+**Real-world consequence:**
+
+- A `lookup_order` tool raises `KeyError` for an unknown id. With
+  `handle_tool_error=True` the model sees `KeyError: 'ORD-991'`, cannot tell that
+  the id was simply wrong, and re-calls with `ORD-991` again. The agent burns its
+  iteration budget on a failure a `{"error": "no such order", "retryable": false}`
+  return would have ended in one turn.
+- A tool wrapping `psycopg2` lets an `OperationalError` escape. The message
+  carries the full DSN — host, port, database, user — into the model's context and
+  into the run transcript.
+- A tool raising on a transient timeout aborts the whole run under the default
+  executor behavior, when the correct handling was a retry.
+
+**Why severity is low and not medium:**  
+The failure degrades recovery and leaks incidentally; it does not by itself grant
+capability or cross a privilege boundary. A raise is also frequently deliberate —
+plenty of tools raise expecting a wrapping frame, a `handle_tool_error` callable,
+or a LangGraph error edge to structure it. Low reflects that this is a reliability
+tax paid on the failure path, not an exploit primitive.
+
+**Fix type — code:**  
+Catching the failure and returning `{"error": ..., "retryable": ...}` is a source
+edit to the tool body. Setting `handle_tool_error` to a mapping function is also a
+code change, in the tool's construction.
+
+**Confidence 0.6:**  
+The check is body-local, which produces error in both directions. False positives:
+a tool that raises deliberately because a wrapping decorator, a `StructuredTool`
+subclass, or a `handle_tool_error` callable converts the exception into exactly the
+structured shape this rule asks for — the structure exists, just not in this body.
+False negatives: a tool with a `try`/`except` that catches and then re-raises, or
+catches and returns a bare string, satisfies the predicate while having no more of
+a contract than a bare raise. 0.6 is the honest read of a single-frame syntactic
+check standing in for a whole-call-path property.
+
+---
+
+## What this policy does not cover
+
+- Exception handling performed by a wrapping frame — a decorator, a
+  `StructuredTool` subclass, a `handle_tool_error` callable, or a LangGraph error
+  edge — outside the tool body.
+- A `try`/`except` that catches and re-raises, or that returns an unstructured
+  string. Both satisfy the predicate without providing a contract.
+- Whether the returned structured error is *correct* — that `retryable` reflects
+  reality, or that the message tells the model what to change.
+- Whether the raised or returned message actually contains sensitive data; the
+  disclosure risk is inferred from the pattern, not confirmed by inspecting it.
+- TypeScript LangChain tools. No raise/catch predicate is wired for TS today, so
+  `LC-010`..`LC-014`'s language has no error-contract counterpart.
+
+---
+
+## Recommendations beyond the fix
+
+```python
+from langchain_core.tools import tool
+
+
+@tool
+def lookup_order(order_id: str) -> dict:
+    """Look up an order by id."""
+    try:
+        return {"ok": True, "order": ORDERS[order_id]}
+    except KeyError:
+        return {"ok": False, "error": "no order with that id", "retryable": False}
+    except TimeoutError:
+        return {"ok": False, "error": "order service timed out", "retryable": True}
+```
+
+1. Return a result object with a `retryable` field on every failure path. That one
+   boolean is what lets the model choose between correcting its arguments and
+   waiting, instead of repeating the call until `max_iterations` ends the run.
+2. Name the offending input in the error message ("no order with that id"), not the
+   exception type. The model rewrites its next call from that string.
+3. If you rely on the executor to relay errors, set `handle_tool_error` to a
+   *function* that maps the exception to the same structured shape — `True` only
+   stringifies it.
+4. Never pass a raw `str(e)` from a database or filesystem client through to the
+   model; it carries paths and connection strings into the transcript.

--- a/docs/Policy/pydantic_ai/error_handling.md
+++ b/docs/Policy/pydantic_ai/error_handling.md
@@ -1,0 +1,158 @@
+---
+policy_id: pydantic_ai_error_handling
+category: pydantic_ai
+topic: error_handling
+rules:
+  - id: PYD-008
+    severity: low
+    confidence: 0.6
+    scope: tool
+    fix_type: code
+references: [LLM05]
+---
+
+# Policy Rationale: Pydantic AI Error Contract Hygiene
+
+**Policy ID:** `pydantic_ai_error_handling`  
+**File:** `pydantic_ai/error_handling.yaml`  
+**Rules:** PYD-008  
+**Severities:** low  
+**Fix types:** code  
+**References:** LLM05 (Improper Output Handling)
+
+> Shares the structured-error threat model with
+> [openai_sdk/error_handling.md](../openai_sdk/error_handling.md). Pydantic
+> AI-specific angle only.
+
+---
+
+## What this policy covers
+
+A Pydantic AI tool — a function registered with `@agent.tool` or
+`@agent.tool_plain`, or passed via `tools=` — whose body contains a `raise` and
+no `try`/`except`, detected by
+`all: [has_raise: true, has_try_except: false]`.
+
+---
+
+## Why error handling is a distinct concern in agent tools
+
+Pydantic AI is the framework in this set that already has the right answer built
+in, which is what makes an uncaught raise here a sharper defect than elsewhere.
+
+The framework recognizes two kinds of tool failure and routes them differently.
+`ModelRetry` is the recoverable channel: the framework catches it, feeds the
+message back to the model as guidance, and lets it call the tool again with
+corrected arguments, bounded by the tool's `retries` setting. Every *other*
+exception is the unrecoverable channel: it propagates out of `agent.run()` and
+ends the run. The two paths are not a convention — they are the framework's
+control flow.
+
+A tool that lets whatever the underlying library raised escape is therefore not
+merely failing to add structure; it is routing failures into the wrong channel.
+A `ValidationError` on a malformed argument, a `KeyError` on a bad id, a 404 from
+an HTTP client — all are precisely the failures the model could correct on a
+second attempt, and all of them take the terminating path because the tool never
+translated them. The retry mechanism the framework provides sits unused while the
+run aborts. The caller sees an exception from `agent.run()` and cannot tell a
+genuine outage from an argument the model chose badly.
+
+The ordinary disclosure concern applies as well: whether the exception ends the
+run or is surfaced to the model, `str(e)` from a database or filesystem error
+carries paths, hostnames and connection strings across a boundary they were not
+meant to cross (improper output handling, LLM05).
+
+---
+
+## Rule-by-rule defense
+
+### PYD-008 — Pydantic AI tool raises exceptions without a structured error contract (Severity: low, Confidence: 0.6, Fix type: code)
+
+**What we detect:**  
+A tool function body containing at least one `raise` statement and no
+`try`/`except` block anywhere in that body.
+
+**Why it is flaggable:**  
+Without a local handler, the tool cannot be choosing between the framework's two
+error channels — every failure it produces takes whichever path the underlying
+library's exception type happens to imply, which for anything other than a
+deliberate `ModelRetry` is the run-terminating one.
+
+**Real-world consequence:**
+
+- A `get_account` tool raises `KeyError` for an unknown id. Rather than the model
+  being told the id was wrong and retrying with a correct one, `agent.run()`
+  raises and the run ends. The recoverable failure was routed as fatal.
+- A tool calling `httpx` lets `HTTPStatusError` escape on a 404. The run aborts on
+  a condition a `ModelRetry("no record with that id; check the identifier")` would
+  have resolved in one extra turn.
+- A tool raising `OperationalError` from a database client propagates the DSN —
+  host, port, user — out through the exception to whatever logs the failed run.
+
+**Why severity is low and not medium:**  
+The impact is degraded recovery plus an incidental disclosure channel; it grants
+no capability and crosses no privilege boundary. A raise may also be entirely
+deliberate — a `ModelRetry` is itself a `raise`, and a tool that raises it with no
+surrounding `try` is doing exactly the right thing while still matching this
+predicate. Low matches the equivalent rules in the Claude, OpenAI, ADK and MCP
+packs.
+
+**Fix type — code:**  
+Catching the failure and either raising `ModelRetry` with corrective guidance or
+returning `{"error": ..., "retryable": ...}` is a source edit to the tool body.
+
+**Confidence 0.6:**  
+The check is body-local and type-blind, which produces error in both directions.
+The notable false positive is specific to this framework: a tool that raises
+`ModelRetry` directly, with no `try`/`except`, is already using the recoverable
+channel correctly and will still match — the predicate sees a `raise`, not which
+exception. False negatives: a `try`/`except` that catches and re-raises, or that
+returns a bare string, satisfies the predicate without providing a contract. 0.6
+reflects a single-frame syntactic check standing in for a whole-call-path
+property.
+
+---
+
+## What this policy does not cover
+
+- Which exception type is raised. A bare `raise ModelRetry(...)` — correct usage
+  — matches this rule, because the predicate is type-blind.
+- Exception handling by a wrapping frame outside the tool body.
+- A `try`/`except` that catches and re-raises, or returns an unstructured string.
+- Whether the tool's `retries` setting is configured sensibly, or whether a
+  `ModelRetry` message actually tells the model what to change.
+- Whether the message contains sensitive data.
+- Output validators and `@agent.output_validator`, which have their own retry
+  path and are not tool bodies.
+
+---
+
+## Recommendations beyond the fix
+
+```python
+from pydantic_ai import Agent, ModelRetry
+
+agent = Agent("openai:gpt-4o")
+
+
+@agent.tool_plain(retries=2)
+def get_account(account_id: str) -> dict:
+    """Get an account by id."""
+    try:
+        return {"account": ACCOUNTS[account_id]}
+    except KeyError:
+        # Recoverable: hand the model something it can act on.
+        raise ModelRetry(f"no account {account_id!r}; ids look like ACC-12345")
+    except TimeoutError:
+        return {"error": "account service timed out", "retryable": True}
+```
+
+1. Decide, per failure, which of the framework's two channels it belongs in.
+   `ModelRetry` for anything the model could fix by calling differently; a
+   propagating exception only for states no retry resolves.
+2. Write the `ModelRetry` message as an instruction, not a diagnosis. "ids look like
+   ACC-12345" changes the next call; "KeyError" does not.
+3. Set `retries` on the tool to bound the corrective loop, so a model that cannot
+   find a valid argument fails cleanly rather than retrying indefinitely.
+4. Never let a client library's exception escape untranslated — besides ending the
+   run, `str(e)` from a database client carries the DSN out with it.


### PR DESCRIPTION
Third leg of a three-repo change:

| repo | PR |
|---|---|
| `trustabl-rules` | trustabl/trustabl-rules#81 — the four rule YAMLs |
| `trustabl` | trustabl/trustabl#125 — fixture mirror + fire/silent cases |
| **`trustabl-rulebook`** | **this** — the rationale docs |

## Why

Claude, OpenAI, Google ADK and MCP each ship a rule for a tool that raises without catching (CSDK-005, OAI-008, ADK-005, MCP-006). LangChain, CrewAI, AutoGen and Pydantic AI ship none — the same defect goes unreported in four of the five packs listed as weakest coverage. The rules PR adds LC-007, CREW-007, AG2-013 and PYD-008; these are their rationale docs.

## The threat model is written per SDK

The predicate is shared. The consequence is not, so each doc argues its own mechanism rather than cross-referencing a generic one:

- **LangChain** — without `handle_tool_error` the exception aborts the run, so a recoverable 404 ends the agent; with it, the exception is stringified into a `ToolMessage` the model reads as prose with no field to branch on.
- **CrewAI** — the error lands in the scratchpad, and a *delegating* agent reads the same opaque text with strictly less context than the agent that made the call. Failures degrade as they propagate through the crew.
- **AutoGen** — the error becomes durable conversation state. `GroupChatManager` re-sends the transcript when prompting each speaker, so one traceback is re-tokenized by every agent on every round.
- **Pydantic AI** — the framework already has the right answer. `ModelRetry` is the recoverable channel; every other exception propagates out of `agent.run()` and ends the run. A bare raise routes recoverable failures down the terminating path while the retry mechanism sits unused.

## Honest limitations

Each doc's "does not cover" section names the shared blind spots — a wrapping frame that structures the exception, a `try`/`except` that re-raises or returns a bare string, and whether the structured error is *correct*.

The Pydantic AI doc records a false positive specific to that framework, in both the confidence section and the exclusions: **a bare `raise ModelRetry(...)` is correct usage and still matches**, because the predicate sees a `raise` and not which exception. That is the main reason confidence sits at 0.6.

## Gate

```
$ python3 tools/check_rulebook.py --rules-repo ../trustabl-rules
rules pack: 210 rules
rationale docs: 89 (89 with front-matter)
ERROR rule OAI-112 ... has no rationale doc
ERROR rule PYD-106 ... has no rationale doc
FAILED: 2 error(s), 0 warning(s).
```

Both remaining errors are **pre-existing on `main`** — verified by running the gate on a clean checkout, where it fails with the same two and nothing else. All four rules added here are covered and consistent. I'll send those two as a separate PR.

## Not included: POLICY_INDEX

`tools/gen_index.py` regenerates every index file, and those are already stale on `main` (they are missing CSDK-017/018/204, OAI-112, PYD-106 and others). Running it here would bury four new rows in ~290 lines of unrelated churn, so the regeneration goes in its own PR.