### PR TITLE
feat(tools): validate policy_id against the pack

### DIFF
--- a/tools/check_rulebook.py
+++ b/tools/check_rulebook.py
@@ -226,6 +226,9 @@ def check(
     warnings: list[str] = []
 
     documented: set[str] = set()
+    # policy_id disagreements are a per-doc fact; report each doc once rather
+    # than once per rule it carries.
+    pid_reported: set[Path] = set()
 
     for doc in docs:
         rel = doc.path.relative_to(rulebook_repo).as_posix()
@@ -244,6 +247,20 @@ def check(
                 )
                 continue
             documented.add(rid)
+
+            # PLACEMENT — policy_id. The template guide calls this a MUST
+            # ("MUST equal policy.id in the paired YAML") and nothing enforced
+            # it: the field was parsed on both sides and never compared.
+            if (
+                doc.policy_id
+                and doc.policy_id != spec.policy_id
+                and doc.path not in pid_reported
+            ):
+                pid_reported.add(doc.path)
+                errors.append(
+                    f"{rel}: policy_id {doc.policy_id!r} != pack "
+                    f"{spec.policy_id!r} ({spec.source})"
+                )
 
             # CONSISTENCY
             if dr.severity is not None and dr.severity != spec.severity:


### PR DESCRIPTION
The template guide calls this a **MUST**:

> `policy_id: openai_sdk_ssrf` — MUST equal `policy.id` in the paired YAML

Nothing enforced it. Both sides were already loaded — `RuleSpec.policy_id` from the pack, `RationaleDoc.policy_id` from front-matter — and never compared. The field was dead data and the MUST was advisory.

**Why it is worth checking rather than deleting:** a wrong `policy_id` survives every other gate. `category` and `topic` are validated against the file's own path, so a doc copied from a neighbouring policy and edited imperfectly keeps its source's id and still passes placement cleanly.

All 85 docs agree today, so this lands clean.

**Verified by mutation, not by silence.** Typing `mcp_netwrok` in `mcp/network.md`:

```
ERROR docs/Policy/mcp/network.md: policy_id 'mcp_netwrok' != pack 'mcp_network' (mcp/network.yaml)
```

Restoring it clears. Reports once per doc rather than once per rule it carries.

Independent of #42 and #47 despite touching the same function — verified by test-merging against that stack: `Auto-merging tools/check_rulebook.py`, no conflict, and the combined gate behaves as expected.