### PR TITLE
fix(make): invoke python3, not python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@
 
 RULES_REPO ?= ../trustabl-rules
 PDF_ENGINE ?= xelatex
+# `python` is not a thing on a stock macOS (and need not exist anywhere);
+# the tools are python3. Override if your interpreter lives elsewhere.
+PYTHON     ?= python3
 BUILD_DIR  := build
 BOOK_MD    := $(BUILD_DIR)/trustabl-rulebook.md
 BOOK_PDF   := $(BUILD_DIR)/trustabl-rulebook.pdf
@@ -21,15 +24,15 @@ book: check index assemble pdf
 
 # Fail if the rationale docs drift from the shipped pack.
 check:
-	python tools/check_rulebook.py --rules-repo $(RULES_REPO)
+	$(PYTHON) tools/check_rulebook.py --rules-repo $(RULES_REPO)
 
 # Regenerate the POLICY_INDEX files (and fail if they were stale in CI: add --check).
 index:
-	python tools/gen_index.py --rules-repo $(RULES_REPO)
+	$(PYTHON) tools/gen_index.py --rules-repo $(RULES_REPO)
 
 # Assemble all chapters + appendix into one markdown.
 assemble:
-	python tools/build_book.py --rules-repo $(RULES_REPO) --out $(BOOK_MD)
+	$(PYTHON) tools/build_book.py --rules-repo $(RULES_REPO) --out $(BOOK_MD)
 
 # Render the PDF (requires pandoc + a LaTeX engine).
 pdf: $(BOOK_MD)


### PR DESCRIPTION
Every recipe ran `python`. On a stock macOS that command does not exist — Python 2 is gone and the system ships only `python3` — so `make check`, `make index`, `make assemble` and `make book` all fail before reaching the tool.

Where a version manager does put a `python` shim on PATH, it resolves to whatever that manager is pinned at. On my machine:

```
$ make check
mise use -g python@3.13.14
mise ERROR Version: 2026.7.0 macos-arm64
make: *** [check] Error 1
```

The Makefile's own header already says **"Requirements: python3 + pyyaml"**; the recipes just did not agree with it.

Uses `PYTHON ?= python3` rather than hardcoding, matching the existing `RULES_REPO ?=` / `PDF_ENGINE ?=` override style, so an unusual interpreter path stays a one-variable change.

After the fix `make check` reaches the tool and reports the real state (the two known OAI-112/PYD-106 coverage errors that #25/#31 fix), and `make index` regenerates.

CI is unaffected — `setup-python` provides both names, which is why this only ever bit local runs. Same shape as #39.