### PR TITLE
feat(tools): gate internal markdown links

### DIFF
--- a/.github/workflows/rulebook.yml
+++ b/.github/workflows/rulebook.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Consistency gate
         run: python tools/check_rulebook.py --rules-repo .rules --strict
 
+      # Every relative link and #anchor between docs resolves. Needs no rules
+      # checkout: this one is purely about the rulebook's internal wiring.
+      - name: Internal links resolve
+        run: python tools/check_links.py
+
       # The committed POLICY_INDEX files match what the generator would produce.
       - name: Index is up to date
         run: python tools/gen_index.py --rules-repo .rules --check

--- a/tools/README.md
+++ b/tools/README.md
@@ -92,3 +92,22 @@ assemble smoke test) gates every PR, and a `build-pdf` job renders and uploads t
 PDF artifact. The workflow checks out `trustabl-rules` into `.rules` and passes
 `--rules-repo .rules`. If `trustabl-rules` is private, set the `RULES_REPO_TOKEN`
 secret to a PAT with read access; for a public pack the default token suffices.
+
+## `check_links.py` — internal-link gate
+
+Resolves every relative markdown link in the repo, and every `#anchor` against
+the target file's real headings (GitHub slug rules). The rationale docs lean on
+cross-references — one doc carries a threat model and its siblings defer to it —
+so a dead link silently removes the half of the argument that was deferred away.
+`check_rulebook.py` cannot see this: it checks docs against the rule pack, not
+against each other.
+
+```bash
+python tools/check_links.py            # whole repo
+python tools/check_links.py --root .   # or an explicit root
+```
+
+Links inside fenced code blocks are skipped, so an illustrative path in the
+template guide is not mistaken for a real one. Exit code `0` = every link
+resolves, `1` = at least one does not. Runs in CI in the `consistency` job; it
+needs no `trustabl-rules` checkout.

--- a/tools/check_links.py
+++ b/tools/check_links.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Internal-link gate for the rulebook.
+
+Every relative markdown link in this repo must resolve, and every `#anchor`
+must name a heading that exists in the target file. A rationale doc that defers
+its threat model to a sibling — "Read openai_sdk/ssrf.md for the full rationale"
+— is only as good as that link; when the target moves or was never written, the
+reader is left with the half of the argument that was deferred away.
+
+Nothing else checks this. check_rulebook.py validates a doc against the rule
+pack; the links between docs are invisible to it.
+
+Links inside fenced code blocks are skipped: the template guide illustrates the
+cross-reference pattern with a sample path that is correct from a policy doc's
+location and not from the guide's own.
+
+Usage:
+    python3 tools/check_links.py [--root PATH]
+
+Exit code: 0 = every link resolves, 1 = at least one does not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# .rules is where the CI workflow checks out trustabl-rules, inside this repo.
+# Without skipping it this gate would walk that repo's markdown and fail the
+# rulebook's build over links belonging to a different project.
+SKIP_DIRS = {".git", ".rules", "build", "node_modules"}
+# [text](target) where target is not a URL, mailto:, or a bare anchor.
+LINK_RE = re.compile(r"\[[^\]]*\]\((?!https?://|mailto:|#)([^)\s]+?)(#[^)\s]*)?\)")
+HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.MULTILINE)
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+
+def strip_fences(text: str) -> str:
+    """Blank out fenced code blocks, preserving line count for reporting."""
+    out, in_fence = [], False
+    for line in text.splitlines():
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            out.append("")
+            continue
+        out.append("" if in_fence else line)
+    return "\n".join(out)
+
+
+def slug(heading: str) -> str:
+    """GitHub's heading-anchor slug: lowercase, drop punctuation, spaces to -."""
+    s = heading.strip().lower()
+    s = re.sub(r"[^\w\s-]", "", s)
+    return re.sub(r"\s+", "-", s)
+
+
+def anchors(path: Path) -> set[str]:
+    return {slug(h) for h in HEADING_RE.findall(path.read_text(encoding="utf-8"))}
+
+
+def markdown_files(root: Path) -> list[Path]:
+    return sorted(
+        p for p in root.rglob("*.md")
+        if not any(part in SKIP_DIRS for part in p.relative_to(root).parts)
+    )
+
+
+def check(root: Path) -> list[str]:
+    errors: list[str] = []
+    for md in markdown_files(root):
+        body = strip_fences(md.read_text(encoding="utf-8"))
+        for m in LINK_RE.finditer(body):
+            target, anchor = m.group(1), (m.group(2) or "")[1:]
+            rel = md.relative_to(root).as_posix()
+            dest = (md.parent / target).resolve()
+            if not dest.exists():
+                errors.append(f"{rel}: link target does not exist: {target}")
+                continue
+            if anchor and dest.suffix == ".md" and slug(anchor) not in anchors(dest):
+                errors.append(f"{rel}: {target} has no heading anchor #{anchor}")
+    return errors
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Check internal markdown links.")
+    ap.add_argument(
+        "--root",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="repository root to scan (default: this repo)",
+    )
+    args = ap.parse_args()
+    root = Path(args.root).resolve()
+
+    errors = check(root)
+    print(f"checked {len(markdown_files(root))} markdown file(s) under {root}\n")
+    for e in errors:
+        print(f"ERROR {e}")
+    if errors:
+        print(f"\nFAILED: {len(errors)} broken link(s).")
+        return 1
+    print("OK: every internal link and anchor resolves.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
⚠️ **Merge after #26**, which fixes the four links this reports.

A rationale doc that defers its threat model to a sibling — *"Read `openai_sdk/ssrf.md` for the full rationale"* — is only as good as that link. When the target moves or was never written, the reader is left holding the half of the argument that was deferred away.

Nothing notices: `check_rulebook.py` validates docs against the rule *pack*; the links *between* docs are invisible to it. That is how four references to `openai_sdk/ssrf.md` — a file that has never existed — survived in `langchain/ssrf.md` and `mcp/ssrf.md`.

Adds `tools/check_links.py` plus a CI step. It resolves every relative markdown link repo-wide (99 files) and every `#anchor` against the target's real headings using GitHub's slug rules.

**On `main`** it reports exactly the four links #26 fixes. **With #26 merged:**
```
checked 99 markdown file(s)
OK: every internal link and anchor resolves.
```

**Anchor half verified by mutation** — `#recommendations-beyond-the-fixx`:
```
ERROR docs/Policy/langchain/ssrf.md: ../claude_sdk/ssrf.md has no heading anchor #recommendations-beyond-the-fixx
```

**Fenced code blocks are skipped.** The template guide illustrates the cross-reference pattern with `../claude_sdk/path_safety.md`, correct from a policy doc's location but not from the guide's own. Flagging it would be wrong, and an earlier version of my audit did exactly that.

The CI step needs no `trustabl-rules` checkout — this gate is purely about the rulebook's internal wiring.