### PR TITLE
docs: document OAI-112 and PYD-106, turning the consistency gate green

### DIFF
--- a/docs/Policy/openai_sdk/agent_safety.md
+++ b/docs/Policy/openai_sdk/agent_safety.md
@@ -38,17 +38,22 @@ rules:
     confidence: 0.6
     scope: agent
     fix_type: config
-references: [LLM01, LLM06]
+  - id: OAI-112
+    severity: low
+    confidence: 0.6
+    scope: agent
+    fix_type: config
+references: [LLM01, LLM06, LLM10]
 ---
 
 # Policy Rationale: Agent Wiring Safety
 
 **Policy ID:** `openai_sdk_agent_safety`  
 **File:** `openai_sdk/agent_safety.yaml`  
-**Rules:** OAI-101, OAI-102, OAI-103, OAI-104, OAI-105, OAI-109, OAI-110  
-**Severities:** high, high, high, medium, high, high, medium  
-**Fix types:** config, config, config, config, config, config, config  
-**References:** LLM01, LLM06
+**Rules:** OAI-101, OAI-102, OAI-103, OAI-104, OAI-105, OAI-109, OAI-110, OAI-112  
+**Severities:** high, high, high, medium, high, high, medium, low  
+**Fix types:** config, config, config, config, config, config, config, config  
+**References:** LLM01, LLM06, LLM10 (Unbounded Consumption)
 
 ---
 
@@ -261,6 +266,53 @@ last line before the user/caller.
 **Confidence 0.6:** the lower confidence reflects that many content-fetching agents
 are low-risk (public data, no sensitive egress), so the missing output guardrail is
 often acceptable — a review prompt more than a defect.
+
+
+### OAI-112 — OpenAI Agents SDK agent has no explicit max_turns limit (Severity: low, Confidence: 0.6, Fix type: config)
+
+**What we detect:** no `Runner.run(...)` / `run_sync(...)` / `run_streamed(...)`
+call site resolving to this agent passes a `max_turns=` argument
+(`agent_run_call_max_turns_missing`).
+
+**Why it is flaggable:** the loop still terminates — the SDK applies
+`DEFAULT_MAX_TURNS` — but it terminates at a ceiling nobody chose for this task.
+Two things follow. First, the bound is not sized to the work: a single-lookup
+agent and a multi-step research agent get the same ceiling, so the lookup agent
+that starts oscillating has a long way to run before anything stops it, consuming
+tokens and *tool side effects* the whole way. Second, an implicit ceiling is a
+value the SDK owns; it can move between versions with no change on your side, so
+the effective bound on your agent is a dependency's default rather than a
+deliberate decision (unbounded consumption, LLM10). An explicit cap also converts
+a stuck run into a clean, catchable `MaxTurnsExceeded` at a point you chose,
+instead of a slow burn to a limit you did not.
+
+**Real-world consequence:**
+
+- An agent whose tool call keeps failing retries it for the whole default budget.
+  Because the tools are not read-only, each turn re-issues real side effects —
+  duplicate tickets, repeated writes — not just tokens.
+- An SDK upgrade raises `DEFAULT_MAX_TURNS`. Every agent without an explicit cap
+  silently gets a larger blast radius, and nothing in the diff shows it.
+- A run that stalls is eventually killed by a platform timeout rather than raising
+  `MaxTurnsExceeded`, so the failure arrives with no attributable cause.
+
+**Why severity is low and not medium:** the loop is bounded, just not deliberately,
+and the consequence is cost and duplicated side effects rather than a crossed
+privilege boundary. The rules in this file that grant or fail to screen capability
+(OAI-101 through OAI-110) are the higher-severity ones; this is a hygiene control
+on top of them. Low matches PYD-106, the equivalent bound in the Pydantic AI pack.
+
+**Fix type — config:** `max_turns=` is an argument at the runner call site. No
+agent or tool source changes.
+
+**Confidence 0.6:** the check resolves run call sites statically and errs in both
+directions. False positives: a run invoked through a wrapper, a helper, or a
+`functools.partial` that supplies `max_turns` out of sight of the call site the
+rule reads; and a deployment bounded externally by a platform timeout or budget.
+False negatives: `max_turns` passed but set absurdly high satisfies the predicate
+while bounding nothing in practice — the rule checks that a bound was chosen, not
+that it was chosen well.
+
 
 ---
 

--- a/docs/Policy/pydantic_ai/agent_safety.md
+++ b/docs/Policy/pydantic_ai/agent_safety.md
@@ -23,6 +23,11 @@ rules:
     confidence: 0.7
     scope: agent
     fix_type: config
+  - id: PYD-106
+    severity: low
+    confidence: 0.6
+    scope: agent
+    fix_type: config
 references: [LLM05, LLM06, LLM10]
 ---
 
@@ -30,9 +35,9 @@ references: [LLM05, LLM06, LLM10]
 
 **Policy ID:** `pydantic_ai_agent_safety`  
 **File:** `pydantic_ai/agent_safety.yaml`  
-**Rules:** PYD-101, PYD-102, PYD-103, PYD-105  
-**Severities:** low, high, medium, low  
-**Fix types:** config, config, config, config  
+**Rules:** PYD-101, PYD-102, PYD-103, PYD-105, PYD-106  
+**Severities:** low, high, medium, low, low  
+**Fix types:** config, config, config, config, config  
 **References:** LLM05 (Improper Output Handling), LLM06 (Excessive Agency), LLM10 (Unbounded Consumption)
 
 ---
@@ -47,7 +52,9 @@ type — `output_type` is absent (defaulting to `str`) or set explicitly to `str
 `agent_uses_hosted_tool_class`). **PYD-103** fires when the agent wires a native
 web-retrieval tool — `WebFetchTool`, `UrlContextTool`, or `WebSearchTool` (same
 predicate). **PYD-105** fires when `end_strategy="exhaustive"` (predicate
-`agent_kwarg_value`).
+`agent_kwarg_value`). **PYD-106** fires when no `run`/`run_sync`/`run_stream`
+call that executes this agent passes `usage_limits` (predicate
+`agent_run_call_usage_limits_missing`).
 
 ---
 
@@ -180,6 +187,52 @@ type — config:** the fix is leaving `end_strategy` at its `early` default, a
 constructor change. **Confidence 0.7:** the rule cannot tell whether the agent's
 tools have side effects, so it over-flags exhaustive-mode agents whose tools are
 all read-only.
+
+
+### PYD-106 — Pydantic AI agent has no explicit usage_limits set (Severity: low, Confidence: 0.6, Fix type: config)
+
+**What we detect:** no `agent.run(...)` / `run_sync(...)` / `run_stream(...)` call
+site resolving to this agent passes a `usage_limits=` argument
+(`agent_run_call_usage_limits_missing`).
+
+**Why it is flaggable:** with no `usage_limits`, Pydantic AI applies a bare
+`UsageLimits()`. That is not "no limit" — it is a *request* cap with token and cost
+usage left entirely unbounded. The distinction matters, because the presence of a
+default invites the assumption that spend is bounded when only step count is. A run
+that oscillates, or one whose tool-calling chain balloons, consumes tokens
+proportional to the growing context on every step, and the request cap is a poor
+proxy for that: a handful of requests over a context that has grown to hundreds of
+thousands of tokens costs far more than many requests over a small one (unbounded
+consumption, LLM10).
+
+**Real-world consequence:**
+
+- A research agent re-reads a large document on each of its permitted steps. It
+  stays well inside the request cap while its token spend grows superlinearly with
+  the accumulated context, and nothing stops it.
+- A model that oscillates between two tool calls burns the run's entire token
+  budget without ever tripping the request limit, and the overrun is visible only
+  on the bill.
+- With no limit set, a runaway run ends by exhausting a provider quota or a
+  timeout rather than by raising `UsageLimitExceeded`, so there is no clean signal
+  to catch, attribute, and handle.
+
+**Why severity is low and not medium:** the consequence is cost and latency, not
+capability — no privilege boundary is crossed and no data is exposed. The default
+`UsageLimits()` also does bound request count, so the failure is an unbounded
+*dimension* rather than an unbounded loop. Low matches OAI-112, the equivalent
+turn-bound rule in the OpenAI pack.
+
+**Fix type — config:** `usage_limits=UsageLimits(...)` is an argument at the run
+call site. No tool or agent source changes.
+
+**Confidence 0.6:** the check resolves run call sites statically, which errs in both
+directions. False positives: a run invoked through a wrapper, a helper, or a
+partial that supplies `usage_limits` out of sight of the call site the rule reads;
+and a deployment that bounds spend outside the framework, at a gateway or provider
+quota. False negatives: a `usage_limits=UsageLimits()` passed explicitly but left
+empty satisfies the predicate while bounding nothing more than the default did.
+
 
 ---
 


### PR DESCRIPTION
## The gate is red on `main`

`tools/check_rulebook.py` is the repo's own coverage gate, and it currently fails on a clean checkout — two rules shipped in `trustabl-rules` with no rationale doc covering them:

```
$ python3 tools/check_rulebook.py --rules-repo ../trustabl-rules
rules pack: 206 rules
rationale docs: 85 (85 with front-matter)

ERROR rule OAI-112 (openai_sdk/agent_safety.yaml) has no rationale doc (expected one covering it under docs/Policy/openai_sdk/agent_safety.md)
ERROR rule PYD-106 (pydantic_ai/agent_safety.yaml) has no rationale doc (expected one covering it under docs/Policy/pydantic_ai/agent_safety.md)

FAILED: 2 error(s), 0 warning(s).
```

After this PR:

```
OK: rulebook consistent (0 warning(s)).
```

## Documented as a pair

OAI-112 and PYD-106 are near-mirrors — one bounds turns, the other bounds usage — so each cites the other in its severity defense rather than arguing `low` from scratch.

Both make the same argument, which is the interesting one: **the concern is not an unbounded loop, it is an undeliberate bound.**

- **OAI-112** — the loop does terminate, at `DEFAULT_MAX_TURNS`. But that ceiling is not sized to the task (a single-lookup agent and a research agent get the same one), and it is a value the SDK owns — an upgrade can move it with nothing in your diff to show it.
- **PYD-106** — the bare `UsageLimits()` default is *worse* than no default, because it bounds request count while leaving tokens and cost unbounded. A run whose context grows on every step can stay well inside the request cap while its spend grows superlinearly. The presence of a default invites the assumption that spend is capped when only step count is.

Both note that side effects, not just tokens, are what a long default budget re-issues: a retrying tool that is not read-only files duplicate tickets on every turn.

## Honest limits

Each `Confidence 0.6` section names failures in both directions, including the false negative the predicate structurally cannot catch: **a bound passed but set absurdly high — or a `UsageLimits()` passed explicitly but left empty — satisfies the check while bounding nothing.** The rule verifies a bound was chosen, not that it was chosen well.

Front-matter `severity`/`confidence`/`scope` were taken from the YAML and are checked by the gate. `references` gains `LLM10` (Unbounded Consumption) on the OpenAI doc, which previously listed only LLM01/LLM06.

Independent of my other rulebook PR (#49); no file overlap.