### PR TITLE
docs(tools): state the python version the tools actually support

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -3,7 +3,9 @@
 Both tools read the shipped pack from a sibling `trustabl-rules` checkout
 (override with `--rules-repo` or `$TRUSTABL_RULES_REPO`) and share one rule
 loader (`check_rulebook.load_rules`), so they can never disagree about what
-ships. Requires python 3.11+ and pyyaml.
+ships. Requires python 3.9+ and pyyaml — 3.9 because that is the interpreter a
+stock macOS provides, and the tools are deliberately kept runnable on it (see
+the `write_bytes` note in `gen_index.py`). CI pins 3.12.
 
 ## `build_book.py` + `make book` — PDF build
 
@@ -68,7 +70,7 @@ It reads the YAML front-matter required on every `docs/Policy/<category>/<topic>
 ### Usage
 
 ```bash
-# Requires: python 3.11+, pyyaml. A sibling trustabl-rules checkout.
+# Requires: python 3.9+, pyyaml. A sibling trustabl-rules checkout.
 python tools/check_rulebook.py                       # ../trustabl-rules by default
 python tools/check_rulebook.py --rules-repo /path/to/trustabl-rules
 python tools/check_rulebook.py --strict              # docs without front-matter are errors, not warnings


### PR DESCRIPTION
⚠️ **Depends on #39.** Without that fix `build_book.py` genuinely does not run on 3.9, and this claim would be false.

`tools/README.md` asks for **python 3.11+** in two places. But `gen_index.py` deliberately avoids `write_text`'s `newline` kwarg *specifically so it runs on 3.9*, and says so in a comment:

> ... AND runs on Python 3.9 — write_text's newline kwarg is 3.10+, which crashed regeneration under the repo's default python3.

The README and the code disagreed about who the tools are for. 3.9 is what a stock macOS provides, which is exactly the contributor the "no toolchain needed" local workflow is aimed at.

Verified all of them under 3.9.6 — annotations are postponed by `from __future__ import annotations`, and nothing else needs a newer runtime:

```
check_rulebook  exit=1  (real findings — ran fine)
gen_index       exit=1  (stale index — ran fine)
build_book      imports OK   (executes with #39)
check_links     OK          (added in #52)
```

States 3.9+, names the reason so the constraint is not silently dropped later, and notes CI pins 3.12.