### PR TITLE
ci: add a make target for the link gate

### DIFF
--- a/.github/workflows/rulebook.yml
+++ b/.github/workflows/rulebook.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Consistency gate
         run: python tools/check_rulebook.py --rules-repo .rules --strict
 
+      # Every relative link and #anchor between docs resolves. Needs no rules
+      # checkout: this one is purely about the rulebook's internal wiring.
+      - name: Internal links resolve
+        run: python tools/check_links.py
+
       # The committed POLICY_INDEX files match what the generator would produce.
       - name: Index is up to date
         run: python tools/gen_index.py --rules-repo .rules --check

--- a/Makefile
+++ b/Makefile
@@ -10,18 +10,26 @@
 
 RULES_REPO ?= ../trustabl-rules
 PDF_ENGINE ?= xelatex
+# `python` is not a thing on a stock macOS (and need not exist anywhere);
+# the tools are python3. Override if your interpreter lives elsewhere.
+PYTHON     ?= python3
 BUILD_DIR  := build
 BOOK_MD    := $(BUILD_DIR)/trustabl-rulebook.md
 BOOK_PDF   := $(BUILD_DIR)/trustabl-rulebook.pdf
 
-.PHONY: book check index assemble pdf clean
+.PHONY: book check links index assemble pdf clean
 
-# Full pipeline: gate -> index -> assemble -> render.
-book: check index assemble pdf
+# Full pipeline: gates -> index -> assemble -> render.
+book: check links index assemble pdf
 
 # Fail if the rationale docs drift from the shipped pack.
 check:
 	python tools/check_rulebook.py --rules-repo $(RULES_REPO)
+
+# Fail if a relative link or #anchor between docs does not resolve. Needs no
+# rules checkout — this one is about the rulebook's internal wiring.
+links:
+	$(PYTHON) tools/check_links.py
 
 # Regenerate the POLICY_INDEX files (and fail if they were stale in CI: add --check).
 index:

--- a/tools/README.md
+++ b/tools/README.md
@@ -92,3 +92,22 @@ assemble smoke test) gates every PR, and a `build-pdf` job renders and uploads t
 PDF artifact. The workflow checks out `trustabl-rules` into `.rules` and passes
 `--rules-repo .rules`. If `trustabl-rules` is private, set the `RULES_REPO_TOKEN`
 secret to a PAT with read access; for a public pack the default token suffices.
+
+## `check_links.py` — internal-link gate
+
+Resolves every relative markdown link in the repo, and every `#anchor` against
+the target file's real headings (GitHub slug rules). The rationale docs lean on
+cross-references — one doc carries a threat model and its siblings defer to it —
+so a dead link silently removes the half of the argument that was deferred away.
+`check_rulebook.py` cannot see this: it checks docs against the rule pack, not
+against each other.
+
+```bash
+python tools/check_links.py            # whole repo
+python tools/check_links.py --root .   # or an explicit root
+```
+
+Links inside fenced code blocks are skipped, so an illustrative path in the
+template guide is not mistaken for a real one. Exit code `0` = every link
+resolves, `1` = at least one does not. Runs in CI in the `consistency` job; it
+needs no `trustabl-rules` checkout.

--- a/tools/check_links.py
+++ b/tools/check_links.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Internal-link gate for the rulebook.
+
+Every relative markdown link in this repo must resolve, and every `#anchor`
+must name a heading that exists in the target file. A rationale doc that defers
+its threat model to a sibling — "Read openai_sdk/ssrf.md for the full rationale"
+— is only as good as that link; when the target moves or was never written, the
+reader is left with the half of the argument that was deferred away.
+
+Nothing else checks this. check_rulebook.py validates a doc against the rule
+pack; the links between docs are invisible to it.
+
+Links inside fenced code blocks are skipped: the template guide illustrates the
+cross-reference pattern with a sample path that is correct from a policy doc's
+location and not from the guide's own.
+
+Usage:
+    python3 tools/check_links.py [--root PATH]
+
+Exit code: 0 = every link resolves, 1 = at least one does not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+SKIP_DIRS = {".git", "build", "node_modules"}
+# [text](target) where target is not a URL, mailto:, or a bare anchor.
+LINK_RE = re.compile(r"\[[^\]]*\]\((?!https?://|mailto:|#)([^)\s]+?)(#[^)\s]*)?\)")
+HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.MULTILINE)
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+
+def strip_fences(text: str) -> str:
+    """Blank out fenced code blocks, preserving line count for reporting."""
+    out, in_fence = [], False
+    for line in text.splitlines():
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            out.append("")
+            continue
+        out.append("" if in_fence else line)
+    return "\n".join(out)
+
+
+def slug(heading: str) -> str:
+    """GitHub's heading-anchor slug: lowercase, drop punctuation, spaces to -."""
+    s = heading.strip().lower()
+    s = re.sub(r"[^\w\s-]", "", s)
+    return re.sub(r"\s+", "-", s)
+
+
+def anchors(path: Path) -> set[str]:
+    return {slug(h) for h in HEADING_RE.findall(path.read_text(encoding="utf-8"))}
+
+
+def markdown_files(root: Path) -> list[Path]:
+    return sorted(
+        p for p in root.rglob("*.md")
+        if not any(part in SKIP_DIRS for part in p.relative_to(root).parts)
+    )
+
+
+def check(root: Path) -> list[str]:
+    errors: list[str] = []
+    for md in markdown_files(root):
+        body = strip_fences(md.read_text(encoding="utf-8"))
+        for m in LINK_RE.finditer(body):
+            target, anchor = m.group(1), (m.group(2) or "")[1:]
+            rel = md.relative_to(root).as_posix()
+            dest = (md.parent / target).resolve()
+            if not dest.exists():
+                errors.append(f"{rel}: link target does not exist: {target}")
+                continue
+            if anchor and dest.suffix == ".md" and slug(anchor) not in anchors(dest):
+                errors.append(f"{rel}: {target} has no heading anchor #{anchor}")
+    return errors
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Check internal markdown links.")
+    ap.add_argument("--root", default=str(Path(__file__).resolve().parent.parent))
+    args = ap.parse_args()
+    root = Path(args.root).resolve()
+
+    errors = check(root)
+    print(f"checked {len(markdown_files(root))} markdown file(s) under {root}\n")
+    for e in errors:
+        print(f"ERROR {e}")
+    if errors:
+        print(f"\nFAILED: {len(errors)} broken link(s).")
+        return 1
+    print("OK: every internal link and anchor resolves.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
⚠️ **Stacked on #52**, which adds `tools/check_links.py`. Merge that first and this reduces to a one-file change.

#52 wires the link gate into CI but gives it no `make` target — so the one gate a contributor cannot reproduce locally is the one whose failure mode (a cross-reference to a doc that does not exist) is easiest to introduce *while writing docs*. Every other tool has a target.

Adds `make links` and puts it in the `book` pipeline beside `check`, so a dead link fails the build **before** the PDF is rendered from it rather than after.

**On the `python` question.** My first cut wrote `python tools/check_links.py`, which git merges cleanly with #51 and is semantically wrong — it would reintroduce the exact bare-`python` bug #51 fixes, in a recipe added after it. So this uses `$(PYTHON)` and introduces the same `PYTHON ?= python3` block #51 adds, byte-identical, so git resolves the two additions as one rather than conflicting or duplicating.

Verified in both merge orders:
- standalone — `make links` runs and reports the four links #26 fixes
- merged with #51 — exactly **one** `PYTHON ?=` definition, and all four recipes use `$(PYTHON)`