### PR TITLE
ci: allow the book build to be triggered manually

### DIFF
--- a/.github/workflows/rulebook.yml
+++ b/.github/workflows/rulebook.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
   push:
     branches: [main]
+  # The PDF is this repo's product and is built only as a CI artifact, so
+  # without this there is no way to produce one without pushing a commit —
+  # including after a trustabl-rules change that the rulebook itself does not
+  # reflect in a diff.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
The PDF is this repo's product, and it exists only as a CI artifact built on `pull_request` and on push to `main`. There is no way to produce one without pushing a commit.

That bites hardest in the case that most warrants a rebuild: **`trustabl-rules` changed and the rulebook has no diff of its own to push.** The book is assembled from the pack, so its content can go stale without a single line changing here — and today the only way to get a fresh PDF is to invent a commit.

Adds `workflow_dispatch`. Nothing else changes: on a manual run `github.head_ref` is empty, so the existing resolution falls through to `main` and the book builds against the production pack — the same path a push to `main` already takes, and the workflow comments already describe that fallback.

Verified the file still parses, both triggers and both jobs intact, and test-merged against the other two workflow PRs (#52, #58): both clean.

A `rules_ref` input would make manual builds more useful still (render the book against a paired `trustabl-rules` branch), but it overlaps #58's resolution change — happy to follow up once that lands rather than entangle the two.