### PR TITLE
chore: ignore the CI rules checkout path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 # Python
 __pycache__/
 *.pyc
+
+# The CI workflow checks trustabl-rules out here (actions/checkout path: .rules).
+# Mirroring that locally — `--rules-repo .rules` — should not dirty the tree.
+/.rules/


### PR DESCRIPTION
The workflow checks `trustabl-rules` out into `.rules/` **inside this repo**:

```yaml
- name: Checkout trustabl-rules
  uses: actions/checkout@v4
  with:
    repository: trustabl/trustabl-rules
    path: .rules
```

and runs every gate with `--rules-repo .rules`. A contributor reproducing a CI failure locally does exactly that, and ends up with a 206-rule repository sitting untracked in `git status` — easy to sweep into a `git add -A`, and noisy while it lasts.

The tools default to a sibling `../trustabl-rules`, so this only affects people mirroring CI precisely — which is what someone debugging CI does.

Verified `git check-ignore` matches `.rules/` after the change and did not before.

Found while testing #52 against the layout CI actually produces; that PR needed a related fix, since the link gate was walking `.rules/` and checking a different project's markdown.