### PR TITLE
docs(tools): give check_rulebook's flags help text

### DIFF
--- a/tools/check_rulebook.py
+++ b/tools/check_rulebook.py
@@ -39,7 +39,9 @@ Usage:
     --rules-repo  Path to the trustabl-rules checkout (default: ../trustabl-rules,
                   or $TRUSTABL_RULES_REPO).
     --strict      Treat rationale docs with NO front-matter as errors (default:
-                  warn — lets the migration land incrementally).
+                  warn). Every doc carries front-matter and CI passes --strict,
+                  so the lenient default exists only for a work-in-progress doc
+                  on a local run.
 
 Exit code: 0 = clean, 1 = at least one error (or a strict warning).
 """
@@ -306,8 +308,18 @@ def check(
 def main() -> int:
     ap = argparse.ArgumentParser(description="Rulebook consistency gate.")
     default_rules = os.environ.get("TRUSTABL_RULES_REPO", "../trustabl-rules")
-    ap.add_argument("--rules-repo", default=default_rules)
-    ap.add_argument("--strict", action="store_true")
+    ap.add_argument(
+        "--rules-repo",
+        default=default_rules,
+        help="path to the trustabl-rules checkout "
+             "(default: %(default)s, or $TRUSTABL_RULES_REPO)",
+    )
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="treat a doc with no YAML front-matter as an error rather than a "
+             "warning; CI runs with this on",
+    )
     args = ap.parse_args()
 
     rulebook_repo = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
`python3 tools/check_rulebook.py --help` before:

```
optional arguments:
  -h, --help            show this help message and exit
  --rules-repo RULES_REPO
  --strict
```

Both flags were declared with no `help=` at all. The module docstring explains them, but nobody reads a docstring to find out what a flag does. After:

```
  --rules-repo RULES_REPO
                        path to the trustabl-rules checkout (default:
                        ../trustabl-rules, or $TRUSTABL_RULES_REPO)
  --strict              treat a doc with no YAML front-matter as an error
                        rather than a warning; CI runs with this on
```

Also drops the *"lets the migration land incrementally"* note beside `--strict` in the docstring. That migration finished — every doc carries front-matter and CI passes `--strict` — so a contributor reading it would think the gate is softer than it is. Same correction as #38 makes in `tools/README.md`, in the copy that ships with the tool.

Behavior unchanged. Test-merged against the gate PRs that touch this file (#42, #50): both clean, different regions.