### PR TITLE
docs(tools): give gen_index and build_book's flags help text

### DIFF
--- a/tools/build_book.py
+++ b/tools/build_book.py
@@ -118,8 +118,16 @@ def build(repo: Path, rules_repo: Path) -> str:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Assemble the rulebook into one markdown for Pandoc.")
-    ap.add_argument("--rules-repo", default="../trustabl-rules")
-    ap.add_argument("--out", default="build/trustabl-rulebook.md")
+    ap.add_argument(
+        "--rules-repo",
+        default="../trustabl-rules",
+        help="path to the trustabl-rules checkout (default: %(default)s)",
+    )
+    ap.add_argument(
+        "--out",
+        default="build/trustabl-rulebook.md",
+        help="where to write the assembled markdown (default: %(default)s)",
+    )
     args = ap.parse_args()
 
     repo = Path(__file__).resolve().parent.parent

--- a/tools/gen_index.py
+++ b/tools/gen_index.py
@@ -219,7 +219,12 @@ def build_per_sdk(cat: str, rules: list[RuleSpec]) -> str:
 def main() -> int:
     ap = argparse.ArgumentParser(description="Generate rulebook POLICY_INDEX files.")
     default_rules = os.environ.get("TRUSTABL_RULES_REPO", "../trustabl-rules")
-    ap.add_argument("--rules-repo", default=default_rules)
+    ap.add_argument(
+        "--rules-repo",
+        default=default_rules,
+        help="path to the trustabl-rules checkout "
+             "(default: %(default)s, or $TRUSTABL_RULES_REPO)",
+    )
     ap.add_argument("--check", action="store_true", help="fail if regeneration would change a file")
     args = ap.parse_args()
 


### PR DESCRIPTION
`--help` listed these flags bare:

```
$ python3 tools/build_book.py --help
  --rules-repo RULES_REPO
  --out OUT
```

`gen_index`'s `--check` already carried a description, so the omission on its `--rules-repo` reads as an oversight rather than a house style. `build_book` had none at all — including on `--out`, where knowing the default is the difference between finding the assembled markdown and assuming the run produced nothing.

After:
```
  --rules-repo RULES_REPO
                        path to the trustabl-rules checkout (default: ../trustabl-rules)
  --out OUT             where to write the assembled markdown (default: build/trustabl-rulebook.md)
```

Uses `%(default)s` so the shown defaults cannot drift from the values themselves.

Behavior unchanged — `gen_index --check` still reports the same state. Companion to #71, which does the same for `check_rulebook`; kept separate because that one also corrects a stale claim about the front-matter migration and this is purely additive.

Test-merged against the open PRs touching these files (#41, #39, #61): all clean, different regions.