### PR TITLE
fix(build_book): honor TRUSTABL_RULES_REPO like the other tools

### DIFF
--- a/tools/build_book.py
+++ b/tools/build_book.py
@@ -118,8 +118,16 @@ def build(repo: Path, rules_repo: Path) -> str:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Assemble the rulebook into one markdown for Pandoc.")
-    ap.add_argument("--rules-repo", default="../trustabl-rules")
-    ap.add_argument("--out", default="build/trustabl-rulebook.md")
+    ap.add_argument(
+        "--rules-repo",
+        default="../trustabl-rules",
+        help="path to the trustabl-rules checkout (default: %(default)s)",
+    )
+    ap.add_argument(
+        "--out",
+        default="build/trustabl-rulebook.md",
+        help="where to write the assembled markdown (default: %(default)s)",
+    )
     args = ap.parse_args()
 
     repo = Path(__file__).resolve().parent.parent

--- a/tools/build_book.py
+++ b/tools/build_book.py
@@ -31,6 +31,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
 import re
 from collections import defaultdict
 from pathlib import Path
@@ -118,10 +119,15 @@ def build(repo: Path, rules_repo: Path) -> str:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Assemble the rulebook into one markdown for Pandoc.")
+    # Same resolution as check_rulebook.py and gen_index.py: the env var is how
+    # `make book` is pointed at a non-sibling pack, and all three steps of that
+    # pipeline have to agree about which pack they are reading.
+    default_rules = os.environ.get("TRUSTABL_RULES_REPO", "../trustabl-rules")
     ap.add_argument(
         "--rules-repo",
-        default="../trustabl-rules",
-        help="path to the trustabl-rules checkout (default: %(default)s)",
+        default=default_rules,
+        help="path to the trustabl-rules checkout "
+             "(default: %(default)s, or $TRUSTABL_RULES_REPO)",
     )
     ap.add_argument(
         "--out",

--- a/tools/gen_index.py
+++ b/tools/gen_index.py
@@ -219,7 +219,12 @@ def build_per_sdk(cat: str, rules: list[RuleSpec]) -> str:
 def main() -> int:
     ap = argparse.ArgumentParser(description="Generate rulebook POLICY_INDEX files.")
     default_rules = os.environ.get("TRUSTABL_RULES_REPO", "../trustabl-rules")
-    ap.add_argument("--rules-repo", default=default_rules)
+    ap.add_argument(
+        "--rules-repo",
+        default=default_rules,
+        help="path to the trustabl-rules checkout "
+             "(default: %(default)s, or $TRUSTABL_RULES_REPO)",
+    )
     ap.add_argument("--check", action="store_true", help="fail if regeneration would change a file")
     args = ap.parse_args()
 


### PR DESCRIPTION
⚠️ **Stacked on #72** (which adds the `help=` text this edits). Merge that first and this reduces to one commit.

`check_rulebook.py` and `gen_index.py` both resolve their default from the environment:

```python
default_rules = os.environ.get("TRUSTABL_RULES_REPO", "../trustabl-rules")
```

`build_book.py` hardcoded `"../trustabl-rules"`.

**The consequence is a silently split pipeline.** `make book` runs `check → index → assemble → pdf`. Set `TRUSTABL_RULES_REPO` and the first two steps validate and index the pack you named, then `assemble` builds the book from a *different* one — whatever happens to be in the sibling directory — with nothing reporting that the steps disagreed. The gate would certify one pack and the PDF would contain another.

`tools/README.md` already documents the variable as applying to the tools generally ("override with `--rules-repo` or `$TRUSTABL_RULES_REPO`"), which was true of two of the three — and #38 sharpens that line to "All three tools", making the gap a documented promise the code did not keep.

Verified end-to-end (with #39's fix applied, since `build_book` cannot run on 3.9 without it):
```
$ TRUSTABL_RULES_REPO=/path/to/pack python3 tools/build_book.py --out build/t.md
wrote build/t.md      # assembled from the env-var pack, not the sibling
```