### PR TITLE
fix(make): let TRUSTABL_RULES_REPO reach the tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@
 # default; tectonic is the easiest to install for CI — override with
 # `make book PDF_ENGINE=tectonic`).
 
-RULES_REPO ?= ../trustabl-rules
+# $TRUSTABL_RULES_REPO is the documented way to point the tools at a pack that
+# is not a sibling checkout. Make passes --rules-repo explicitly, so without
+# this the variable is silently ignored for every target.
+RULES_REPO ?= $(or $(TRUSTABL_RULES_REPO),../trustabl-rules)
 PDF_ENGINE ?= xelatex
 BUILD_DIR  := build
 BOOK_MD    := $(BUILD_DIR)/trustabl-rulebook.md


### PR DESCRIPTION
Every recipe passes `--rules-repo $(RULES_REPO)` explicitly, and `RULES_REPO` defaulted to a literal `../trustabl-rules`. So the environment variable the tools document and honor is silently discarded for every `make` target:

```
$ TRUSTABL_RULES_REPO=/path/to/pack make -n check
python tools/check_rulebook.py --rules-repo ../trustabl-rules
```

Anyone whose pack is not a sibling checkout sets the documented variable, watches `make` run against the wrong pack, and gets no indication why — the tools honor it, but `make` overrides them on every invocation.

Defaults `RULES_REPO` from the variable instead. Verified all three precedence cases:

| invocation | resolved |
|---|---|
| `TRUSTABL_RULES_REPO=/pack make -n check` | `/pack` |
| `make -n check` | `../trustabl-rules` |
| `TRUSTABL_RULES_REPO=/pack make -n check RULES_REPO=/explicit` | `/explicit` |

An explicit `RULES_REPO=` still wins, and the sibling default still applies when nothing is set.

Found while correcting the description of #73 — I had claimed the env-var gap bit `make book`, and it does not, because `make` never passed the variable through at all. #73 fixes the direct-invocation half; this fixes the `make` half.

Test-merged against the other Makefile PRs (#51, #60): both clean.