### PR TITLE
feat(tools): reject a rule documented in two docs

### DIFF
--- a/tools/check_rulebook.py
+++ b/tools/check_rulebook.py
@@ -226,6 +226,8 @@ def check(
     warnings: list[str] = []
 
     documented: set[str] = set()
+    # rule id -> the doc that claimed it first, for the duplicate message.
+    first_doc: dict[str, str] = {}
     # policy_id disagreements are a per-doc fact; report each doc once rather
     # than once per rule it carries.
     pid_reported: set[Path] = set()
@@ -246,6 +248,18 @@ def check(
                     f"(removed or typo)"
                 )
                 continue
+            # COVERAGE — a rule may be documented once. Two docs claiming the
+            # same rule both satisfy coverage, so nothing caught it, and the
+            # assembled book would carry that rule's defense twice under
+            # different chapters. The likely cause is splitting a policy doc
+            # and copying its front-matter without pruning the id list.
+            if rid in documented:
+                errors.append(
+                    f"{rel}: {rid} is already documented by "
+                    f"{first_doc[rid]}"
+                )
+            else:
+                first_doc[rid] = rel
             documented.add(rid)
 
             # PLACEMENT — policy_id. The template guide calls this a MUST

--- a/tools/check_rulebook.py
+++ b/tools/check_rulebook.py
@@ -226,6 +226,9 @@ def check(
     warnings: list[str] = []
 
     documented: set[str] = set()
+    # policy_id disagreements are a per-doc fact; report each doc once rather
+    # than once per rule it carries.
+    pid_reported: set[Path] = set()
 
     for doc in docs:
         rel = doc.path.relative_to(rulebook_repo).as_posix()
@@ -244,6 +247,20 @@ def check(
                 )
                 continue
             documented.add(rid)
+
+            # PLACEMENT — policy_id. The template guide calls this a MUST
+            # ("MUST equal policy.id in the paired YAML") and nothing enforced
+            # it: the field was parsed on both sides and never compared.
+            if (
+                doc.policy_id
+                and doc.policy_id != spec.policy_id
+                and doc.path not in pid_reported
+            ):
+                pid_reported.add(doc.path)
+                errors.append(
+                    f"{rel}: policy_id {doc.policy_id!r} != pack "
+                    f"{spec.policy_id!r} ({spec.source})"
+                )
 
             # CONSISTENCY
             if dr.severity is not None and dr.severity != spec.severity:


### PR DESCRIPTION
⚠️ **Stacked on #50.** Merge that first and this reduces to one commit.

COVERAGE asks whether every rule has **a** doc — never whether it has exactly **one**. Two docs claiming the same rule both satisfy it, so a duplicate passes silently.

That matters because `build_book.py` projects docs into chapters without deduplicating: the assembled book would carry the rule's defense **twice, in two chapters**, with nothing saying which is current. The plausible cause is splitting a policy doc as a family grows and copying its front-matter without pruning the id list — which is exactly when the two copies begin to diverge.

**Verified by mutation** — adding `MCP-004` to `mcp/idempotency.md`, where `mcp/network.md` already documents it:

```
ERROR docs/Policy/mcp/network.md: MCP-004 is already documented by docs/Policy/mcp/idempotency.md
```

Naming the first claimant matters here: a collision is a fact about a *pair* of files, and an error pointing at only one leaves you grepping for the other.

All 204 documented rules are distinct today, so this lands clean. Test-merged against #62: clean.