### PR TITLE
fix(tools): escape pipes in generated table cells

### DIFF
--- a/tools/build_book.py
+++ b/tools/build_book.py
@@ -36,7 +36,8 @@ from collections import defaultdict
 from pathlib import Path
 
 from check_rulebook import load_rules
-from gen_index import SDK_FULL, SDK_LABEL, SDK_ORDER, numeric_id, risk_score
+from gen_index import (SDK_FULL, SDK_LABEL, SDK_ORDER, escape_cell, numeric_id,
+                       risk_score)
 
 FRONT_MATTER = re.compile(r"^---\n.*?\n---\n", re.DOTALL)
 # A markdown link whose target points at a rulebook .md file -> keep only the text.
@@ -75,8 +76,9 @@ def appendix_table(rules) -> str:
     )
     headers = ["Id", "SDK", "Scope", "Sev", "Conf", "Risk", "Policy"]
     rows = [
-        [r.rule_id, SDK_LABEL.get(r.category, r.category), r.scope, r.severity,
-         f"{r.confidence:.2f}", risk_score(r.severity, r.confidence), r.title]
+        [escape_cell(c) for c in
+         [r.rule_id, SDK_LABEL.get(r.category, r.category), r.scope, r.severity,
+          f"{r.confidence:.2f}", risk_score(r.severity, r.confidence), r.title]]
         for r in ordered
     ]
     widths = [len(h) for h in headers]

--- a/tools/gen_index.py
+++ b/tools/gen_index.py
@@ -119,8 +119,19 @@ def risk_score(severity: str, confidence: float) -> str:
     return f"{val}"
 
 
+def escape_cell(value: str) -> str:
+    """Escape a pipe so a cell cannot break out into an extra column.
+
+    Rule titles and applies_to values are free text authored in another repo;
+    an unescaped `|` in one silently corrupts the published table row.
+    """
+    return value.replace("|", "\\|")
+
+
 def render_table(headers: list[str], rows: list[list[str]]) -> str:
     """Render a GitHub markdown table with per-column padding (deterministic)."""
+    headers = [escape_cell(h) for h in headers]
+    rows = [[escape_cell(c) for c in row] for row in rows]
     widths = [len(h) for h in headers]
     for row in rows:
         for i, cell in enumerate(row):


### PR DESCRIPTION
Rule titles and `applies_to` values are free text authored in `trustabl-rules` and dropped straight into markdown tables. A `|` in one breaks the row out into an extra column:

```
| Id    | Policy          |
| ----- | --------------- |
| X-001 | Tool does a | b |     <- four cells in a two-column table
```

That corrupts the published index row and, depending on the renderer, the alignment of everything after it. The PDF's rule-catalog appendix builds its own table the same way and has the same hole.

**No title contains a pipe today (0 of 206), so this is preventive** — stating that plainly rather than implying a live break. It is worth doing because the failure is silent, lands in generated files nobody reads closely, and **originates in a repo this one does not control**: a title authored in `trustabl-rules` would corrupt the rulebook on the next `gen_index` run, with no signal at the point of authorship.

Escaped at the single choke point each table builder already has, so every column is covered rather than the two that happen to be free text today.

Verified:
- `render_table` now emits `Tool does a \| b`, one cell
- **the generated master index is byte-identical** (same sha256 before/after) — no index churn in this PR
- the book still assembles

Test-merged against the open PRs touching these files (#41, #39, #64): all clean.