### PR TITLE
docs(readme): show the rulebook workflow status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # trustabl-rulebook
 
+[![rulebook](https://github.com/trustabl/trustabl-rulebook/actions/workflows/rulebook.yml/badge.svg)](https://github.com/trustabl/trustabl-rulebook/actions/workflows/rulebook.yml)
+
 Index and rationale docs for the [trustabl](https://github.com/trustabl/trustabl)
 static analyzer's policy ruleset. Canonical YAML rules live in
 [trustabl/trustabl-rules](https://github.com/trustabl/trustabl-rules) — this


### PR DESCRIPTION
The README's central claim is that coverage is *enforced*, not asserted — every rule documented, every doc consistent with the pack, checked on each PR. A reader currently has no way to see whether that gate is passing without opening the Actions tab.

Adds the workflow badge under the title, linked to the workflow's runs.

Verified the badge URL returns `200`, so it renders rather than showing a broken image.

Test-merged against #37, which rewrites the section just below: clean.