### PR TITLE
feat(build_book): record which pack the book was built from

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # trustabl-rulebook
 
+[![rulebook](https://github.com/trustabl/trustabl-rulebook/actions/workflows/rulebook.yml/badge.svg)](https://github.com/trustabl/trustabl-rulebook/actions/workflows/rulebook.yml)
+
 Index and rationale docs for the [trustabl](https://github.com/trustabl/trustabl)
 static analyzer's policy ruleset. Canonical YAML rules live in
 [trustabl/trustabl-rules](https://github.com/trustabl/trustabl-rules) — this

--- a/tools/build_book.py
+++ b/tools/build_book.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 from collections import defaultdict
 from pathlib import Path
 
@@ -88,6 +89,24 @@ def appendix_table(rules) -> str:
     return "\n".join([line(headers), sep] + [line(r) for r in rows])
 
 
+def pack_provenance(rules_repo: Path) -> str:
+    """Describe the pack this book was built from, for the catalog header.
+
+    The PDF outlives the checkout it was rendered from, so "which rules is this"
+    has to travel with it. Falls back to the plain path when the pack is not a
+    git checkout (a tarball, a vendored copy) rather than failing the build over
+    provenance.
+    """
+    try:
+        sha = subprocess.run(
+            ["git", "-C", str(rules_repo), "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "the rules pack"
+    return f"trustabl-rules@{sha}" if sha else "the rules pack"
+
+
 def build(repo: Path, rules_repo: Path) -> str:
     rules_map, errors = load_rules(rules_repo)
     if errors:
@@ -107,7 +126,9 @@ def build(repo: Path, rules_repo: Path) -> str:
 
     parts.append(latex("\\appendix"))
     parts.append(latex("\\part{Appendix}"))
-    parts.append("# Rule Catalog\n\nEvery shipped rule, generated from the pack. "
+    parts.append("# Rule Catalog\n\n"
+                 f"Every shipped rule, generated from {pack_provenance(rules_repo)} "
+                 f"({len(rules)} rules). "
                  "Risk = severity weight × confidence × 100.\n\n"
                  + latex("\\footnotesize") + "\n\n"
                  + appendix_table(rules) + "\n\n"


### PR DESCRIPTION
The PDF is a build artifact that outlives the checkout it was rendered from, and it carried **nothing identifying the rules it documents**. Two copies of the book, months apart, are indistinguishable.

That matters here more than for a typical doc build: the entire content is *"these are the rules"*, and `trustabl-rules` ships `attestations.json` with a signature precisely because which version of the pack you have is load-bearing. A rendered rulebook with no pack identity cannot be checked against any of that.

The rule-catalog header now names the pack and its commit:

```
Every shipped rule, generated from trustabl-rules@852b03c (206 rules).
Risk = severity weight × confidence × 100.
```

**Fallback verified**, not assumed — a pack that is not a git checkout (a tarball, a vendored copy) and a path that does not exist both degrade to:

```
Every shipped rule, generated from the rules pack (54 rules).
```

rather than failing a book build over provenance. The `except` catches only `OSError` and `subprocess.CalledProcessError`, so a genuine bug in the call still surfaces instead of being swallowed into "unknown".

The rule count comes from the loaded pack, so it cannot disagree with the table printed directly beneath it.