### PR TITLE
docs(mcp): defend the confidence number on six tool-definition rules

### DIFF
--- a/docs/Policy/mcp/tool_definition.md
+++ b/docs/Policy/mcp/tool_definition.md
@@ -134,6 +134,13 @@ so connecting models send inputs the handler cannot rely on and runtime errors
 surface inside the server. Medium severity: degraded validation is a
 reliability and minor injection-surface concern, not a direct compromise.
 
+**Confidence 0.85:** the predicate reads the signature, so it is right about what
+it saw — the residual gap is a handler that publishes a schema some other way,
+such as one typed argument carrying a Pydantic model while the remaining
+parameters stay bare, which still fires. It does not fire on a handler that takes
+no parameters at all (`has_params` gates it), so the common no-argument tool is
+not swept up.
+
 ### MCP-003 — Ambiguous tool name (Severity: low, Confidence: 0.85, Fix type: code)
 
 **What we detect:** a tool named from a fixed ambiguous set (`process`,
@@ -142,6 +149,13 @@ reliability and minor injection-surface concern, not a direct compromise.
 **Why it is flaggable:** an ambiguous name gives the model no intent signal and
 collides across servers in a shared session. Because an MCP server's consumers
 are not controlled by the author, the cost is paid everywhere it is mounted.
+
+**Confidence 0.85:** the match is exact against a closed list, so a finding is
+never a misreading — the 0.15 is for the case where the name is genuinely
+unambiguous in context, a single-purpose server whose own name supplies the noun.
+The far larger gap is recall, not precision: `search`, `update`, and `get` are
+just as ambiguous in a merged catalog and are not on the list. A clean scan means
+the tool avoided ten specific words, not that its name is good.
 
 ### MCP-011 — TypeScript MCP tool has no description (Severity: low, Confidence: 0.85, Fix type: code)
 
@@ -178,6 +192,12 @@ ambiguous set (`process`, `handle`, `run`, ...) via `name_in`.
 no intent signal and collides across servers in a shared session, and the cost is
 paid by every uncontrolled consumer of the published catalog.
 
+**Confidence 0.85:** same calibration as MCP-003 — an exact match against a
+closed list, so the number reflects how often such a name is defensible rather
+than any doubt about the match. Note the Go list holds nine names, not MCP-003's
+ten: `go` is omitted, since it is far more likely to be an ordinary word here
+than an ambiguous tool name.
+
 ### MCP-017 — C# MCP tool has no description (Severity: low, Confidence: 0.85, Fix type: code)
 
 **What we detect:** an `[McpServerTool]`-attributed C# method with no co-located
@@ -197,6 +217,12 @@ SDK default) is in the fixed ambiguous set (`process`, `handle`, `run`, ...) via
 
 **Why it is flaggable:** identical to MCP-003 / MCP-016 — an ambiguous name gives
 the model no intent signal and collides across servers in a shared session.
+
+**Confidence 0.85:** same calibration as MCP-003 — an exact match against a
+closed list, so the number reflects how often such a name is defensible rather
+than any doubt about the match. Note the C# list holds nine names, not MCP-003's
+ten: `go` is omitted, since it is far more likely to be an ordinary word here
+than an ambiguous tool name.
 
 ### MCP-019 — PHP MCP tool has no description (Severity: low, Confidence: 0.85, Fix type: code)
 
@@ -223,6 +249,12 @@ name gives the model no intent signal and collides across servers in a shared
 session, and the cost is paid by every uncontrolled consumer of the published
 catalog.
 
+**Confidence 0.85:** same calibration as MCP-003 — an exact match against a
+closed list, so the number reflects how often such a name is defensible rather
+than any doubt about the match. Note the PHP list holds nine names, not
+MCP-003's ten: `go` is omitted, since it is far more likely to be an ordinary
+word here than an ambiguous tool name.
+
 ### MCP-021 — Rust MCP tool has no description (Severity: low, Confidence: 0.85, Fix type: code)
 
 **What we detect:** a `#[tool]`-attributed Rust method (official rmcp crate) with
@@ -248,6 +280,12 @@ ambiguous set (`process`, `handle`, `run`, ...) via `name_in`.
 ambiguous name gives the model no intent signal and collides across servers in a
 shared session, and the cost is paid by every uncontrolled consumer of the
 published catalog.
+
+**Confidence 0.85:** same calibration as MCP-003 — an exact match against a
+closed list, so the number reflects how often such a name is defensible rather
+than any doubt about the match. Note the Rust list holds nine names, not
+MCP-003's ten: `go` is omitted, since it is far more likely to be an ordinary
+word here than an ambiguous tool name.
 
 ---
 


### PR DESCRIPTION
The template guide's rule-by-rule instruction is explicit:

> ### "Rule-by-rule defense" — defend the confidence number

I audited all 204 rule sections. **Six** state a confidence in the heading and never mention it again — MCP-002, MCP-003, and the four ambiguous-name siblings (MCP-016/018/020/022), which defer wholesale to MCP-003, which had no defense either. Every other section in the rulebook defends its number.

**For the name rules the honest defense is that precision is not the interesting number.** The match is exact against a closed list, so a finding is never a misreading. The real limit is recall — `search`, `update`, and `get` are just as ambiguous in a merged catalog and are not on the list. A clean scan means the tool avoided ten specific words, not that its name is good. Saying so is more useful than restating that 0.85 is high.

**It also records a difference the docs had asserted away.** The sibling sections say "identical to MCP-003". Measured against the pack:

```
MCP-003 (python): 10 -> [process, handle, run, do, execute, perform, work, go, thing, stuff]
MCP-016 (go):      9 -> [process, handle, run, do, execute, perform, work,     thing, stuff]
MCP-018/020/022:   9 -> ... same nine
```

`go` is Python-only — sensibly, since it is far likelier to be an ordinary word in the others. Each sibling now notes it. (This is the same error I had to correct in #36, which claimed all of them flag ten.)

Prose only; no front-matter or rule content changes, and `check_rulebook --strict` reports the same two pre-existing coverage errors. Test-merged against #36, which appends to the end of this file: clean.