### PR TITLE
docs(mcp): give MCP-004 a real-world consequence

### DIFF
--- a/docs/Policy/mcp/network.md
+++ b/docs/Policy/mcp/network.md
@@ -45,6 +45,15 @@ not just the one request; confidence 0.85 because the missing-kwarg match is a
 structured AST check, with the residual gap being client aliases reached across
 function or module boundaries (resolved only within a single function today).
 
+**Real-world consequence:** a server exposes `fetch_report(report_id)`, which
+calls `requests.get(...)` against an internal reports service with no `timeout=`.
+The service wedges — not down, just never answering — and the handler blocks
+forever. The worker serving that session is now unavailable, so every later tool
+call from that client queues behind a request nobody is waiting for. With a
+handful of sessions in the same state the server stops answering entirely. The
+upstream never returned an error, so nothing logs a failure and the server looks
+healthy while serving nothing.
+
 **Fix type — code:** adding `timeout=` is a source edit to the handler.
 
 ---


### PR DESCRIPTION
The per-rule template requires a concrete example:

> **Real-world consequence:** Give a concrete example — tool name, attacker input or failure scenario, outcome. ... Avoid generic statements ("this could cause problems"). Name the specific damage.

I audited all 204 rule sections: **164 have one, 40 do not**, concentrated in `mcp/` (22) and `langchain/` (12). This is the first of those, taken one doc at a time so each stays reviewable.

MCP-004 argued the mechanism well and left the reader to picture the damage. The scenario now spelled out is the one that makes a missing timeout worse on an MCP server than in a script: the upstream **wedges rather than fails**, so the handler blocks forever, the session's worker is gone, later calls from that client queue behind a request nobody is waiting for — and because no error was ever returned, nothing logs a failure and the server looks healthy while serving nothing.

Prose only; front-matter and rule content untouched, `check_rulebook --strict` reports the same two pre-existing coverage errors.

Placed before **Fix type**, matching the template's field order and the other docs.