### PR TITLE
docs(mcp): give MCP-006 a real-world consequence

### DIFF
--- a/docs/Policy/mcp/error_handling.md
+++ b/docs/Policy/mcp/error_handling.md
@@ -45,6 +45,16 @@ modest disclosure channel, and a handler often raises intentionally for a caller
 or runtime that structures it; confidence 0.6 because the body-only check does
 not see a `try` in a calling frame.
 
+**Real-world consequence:** a `create_invoice` tool raises `KeyError: 'tax_id'`
+on a customer record missing a field. The runtime hands the connecting client an
+opaque protocol error carrying the traceback — absolute server paths, the module
+layout, and whatever argument values appear in the frames. Two things follow.
+The model cannot tell whether the invoice was created before the raise, so it
+does the reasonable thing and calls again, which is how a missing error contract
+turns into the duplicate MCP-007 exists to prevent. And the disclosure crosses a
+trust boundary the author never chose: an MCP server does not know which client
+is connected, so the traceback goes wherever the session goes.
+
 **Fix type — code:** returning a structured `{"error": ..., "retryable": ...}`
 result instead of raising is a source edit.
 


### PR DESCRIPTION
Second of the 40 rule sections missing the concrete example the per-rule template requires (see #87 for the audit).

MCP-006's scenario is worth spelling out because the damage runs in two directions from one raise:

- **Disclosure** — a `KeyError: 'tax_id'` escaping `create_invoice` hands the connecting client the traceback: absolute server paths, module layout, argument values in the frames. An MCP server does not know which client is connected, so that goes wherever the session goes. The author never chose the audience.
- **Duplication** — the model cannot tell whether the invoice was created *before* the raise, so it calls again. A missing error contract is how you arrive at exactly the duplicate MCP-007 exists to prevent.

That second point is the one I'd want a reader to take away: the error-handling rule and the idempotency rule in this same pack are describing two ends of one failure, and neither doc said so.

Prose only. Placed before **Fix type**, matching the template's field order.