### PR TITLE
docs(mcp): give MCP-007 a real-world consequence

### DIFF
--- a/docs/Policy/mcp/idempotency.md
+++ b/docs/Policy/mcp/idempotency.md
@@ -47,6 +47,15 @@ an irreversible side effect with no replay guard. Medium severity, and confidenc
 idempotent, and a mutating tool with a non-obvious name is missed. The finding is
 a prompt to confirm, not a proof.
 
+**Real-world consequence:** a `refund_charge(charge_id, amount_cents)` tool takes
+45 seconds because the payment provider is slow. The connecting client gives up
+at 30 and, having no way to distinguish "did not happen" from "happened but the
+answer was lost", retries. The provider issues a second refund. The customer is
+paid twice, both refunds are legitimate as far as every system involved is
+concerned, and nothing surfaces it until reconciliation days later. No component
+malfunctioned: the tool did exactly what it was asked, twice, because nothing in
+the call let the second request identify itself as the first one again.
+
 **Fix type — code:** accepting an idempotency key and de-duplicating server-side
 is a source edit.
 


### PR DESCRIPTION
Third of the 40 rule sections missing the concrete example the per-rule template requires (audit in #87).

The scenario: `refund_charge` takes 45 seconds because the payment provider is slow. The client gives up at 30 and — having no way to distinguish *"did not happen"* from *"happened but the answer was lost"* — retries. The provider issues a second refund. The customer is paid twice.

**The part worth stating is that nothing malfunctions.** Every component did exactly what it was asked; the tool simply had no way for the second request to identify itself as the first one again. There is no error to alert on and no exception to catch, which is why reconciliation finds it days later and why a static check is the realistic place to catch it at all.

That also justifies the rule's modest confidence being worth acting on: the finding is a prompt to confirm the side effect is replay-safe, and this is what it looks like when it is not.

Prose only. Placed before **Fix type**, matching the template's field order.