### PR TITLE
docs(mcp): give MCP-005 a real-world consequence

### DIFF
--- a/docs/Policy/mcp/path_safety.md
+++ b/docs/Policy/mcp/path_safety.md
@@ -48,6 +48,16 @@ file read/write; confidence 0.7 because the param-is-pathish heuristic can flag 
 parameter that is not actually attacker-influenced, so the finding asks for
 confirmation that the parameter is caller-supplied.
 
+**Real-world consequence:** a documentation server exposes
+`read_doc(relative_path)` over a docs root and passes the parameter straight to
+`open()`. The model is summarizing a page that contains, in ordinary prose, an
+instruction to also read `../../.env` for configuration details. It calls the
+tool with that path, the handler opens it, and the file's contents are returned
+as the tool result — which is to say, into the conversation, and from there to
+whatever the client does with transcripts. The server's own credentials leave the
+host through a read-only documentation tool, and every audit log shows a
+successful `read_doc` call.
+
 **Fix type — code:** resolving the path and asserting an allowed root is a source
 edit to the handler.
 


### PR DESCRIPTION
Fourth of the 40 rule sections missing the concrete example the per-rule template requires (audit in #87).

The scenario deliberately is **not** an attacker typing `../../etc/passwd`, because that is not how this reaches an MCP server. It is a page the model is summarizing that contains, in ordinary prose, an instruction to also read `../../.env` for configuration details. The model calls `read_doc` with that path. The handler opens it. The contents come back as the tool result — into the conversation, and from there wherever the client puts transcripts.

Two details that make it worth writing down:

- **A read-only tool exfiltrates credentials.** Nothing was written, no shell ran, and the tool did exactly what it advertises. "Read-only" is not the same as "safe" once the path is caller-chosen.
- **The audit log shows a successful `read_doc` call.** There is no error and no anomaly to alert on, which is why this is hard to find after the fact and worth catching statically.

Prose only. Placed before **Fix type**, matching the template's field order.