### PR TITLE
   docs: add real-world consequence examples to MCP SSRF rationale

### DIFF
--- a/docs/Policy/mcp/ssrf.md
+++ b/docs/Policy/mcp/ssrf.md
@@ -60,6 +60,8 @@ pivot) is severe, so severity is high; confidence is 0.6 because "non-literal
 URL" includes benign cases where the dynamic part is a fixed-base path segment,
 and the rule cannot prove the value is attacker-reachable.
 
+**Real-world consequence:** a stale, forgotten-but-still-live internal system — one that was supposed to be decommissioned but never was, with credentials for it sitting in an accessible file — is a plausible SSRF target: nobody is watching it, so a steered request against it goes unnoticed until data is already gone. The consequence isn't always data theft, either. In one publicly-relevant case, an attacker used an internal foothold to lock a company and its customers out of a cloud-hosted system entirely — no data was actually accessed (so it wasn't a reportable breach), but the business couldn't operate until a ransom was paid. An SSRF-reachable internal endpoint is a plausible entry point for that class of availability attack, not only for credential exfiltration.
+
 ### MCP-013 — TypeScript MCP tool fetches a caller-controlled URL (SSRF) (Severity: high, Confidence: 0.6, Fix type: code)
 
 **What we detect:** the same pattern in a TypeScript handler — a `fetch`/`axios`/
@@ -68,6 +70,8 @@ concatenation rather than a string literal (captured `dynamic_url` fact).
 
 **Why high / 0.6:** identical mechanism and calibration to MCP-008 on the
 TypeScript SDK; a plain string-literal URL does not fire.
+
+**Real-world consequence:** same consequence class as MCP-008 — stale internal systems and availability/ransom attacks are language-agnostic outcomes of a successful SSRF, not specific to the Python SDK.
 
 ---
 


### PR DESCRIPTION
   Adds concrete real-world examples under MCP-008 and MCP-013 — a stale/forgotten credentialed system, and a ransomware-style availability attack — to ground the existing threat model in specific consequences.