### PR TITLE
docs(pydantic_ai): add PYD-104 force_download rationale

### DIFF
--- a/docs/Policy/pydantic_ai/agent_safety.md
+++ b/docs/Policy/pydantic_ai/agent_safety.md
@@ -18,6 +18,11 @@ rules:
     confidence: 0.75
     scope: agent
     fix_type: config
+  - id: PYD-104
+    severity: medium
+    confidence: 0.8
+    scope: agent
+    fix_type: config
   - id: PYD-105
     severity: low
     confidence: 0.7
@@ -30,9 +35,9 @@ references: [LLM05, LLM06, LLM10]
 
 **Policy ID:** `pydantic_ai_agent_safety`  
 **File:** `pydantic_ai/agent_safety.yaml`  
-**Rules:** PYD-101, PYD-102, PYD-103, PYD-105  
-**Severities:** low, high, medium, low  
-**Fix types:** config, config, config, config  
+**Rules:** PYD-101, PYD-102, PYD-103, PYD-104, PYD-105  
+**Severities:** low, high, medium, medium, low  
+**Fix types:** config, config, config, config, config  
 **References:** LLM05 (Improper Output Handling), LLM06 (Excessive Agency), LLM10 (Unbounded Consumption)
 
 ---
@@ -46,7 +51,11 @@ type — `output_type` is absent (defaulting to `str`) or set explicitly to `str
 **PYD-102** fires when the agent wires `CodeExecutionTool` (predicate
 `agent_uses_hosted_tool_class`). **PYD-103** fires when the agent wires a native
 web-retrieval tool — `WebFetchTool`, `UrlContextTool`, or `WebSearchTool` (same
-predicate). **PYD-105** fires when `end_strategy="exhaustive"` (predicate
+predicate). **PYD-104** fires when a FileUrl-family constructor
+(`ImageUrl` / `AudioUrl` / `VideoUrl` / `DocumentUrl`) or a wired
+`WebFetchTool` sets `force_download` to `True` or `"allow-local"` (predicates
+`agent_file_url_force_download` OR `agent_hosted_tool_kwarg_value`).
+**PYD-105** fires when `end_strategy="exhaustive"` (predicate
 `agent_kwarg_value`).
 
 ---
@@ -73,6 +82,13 @@ Pydantic AI: its built-in fetchers have already needed SSRF hardening
 (CVE-2026-46678 and CVE-2026-25580 cover a metadata-endpoint blocklist that could
 be bypassed via DNS rebinding or alternate IP encodings), so enabling one without
 network-egress controls reintroduces that exposure.
+
+`force_download` (PYD-104) is a sharper form of that same SSRF surface. The
+Pydantic AI default (`False`) passes the URL through to the model provider.
+`force_download=True` makes the *agent host* download it; `"allow-local"` still
+downloads on the host and also permits private IPs, turning off the private-range
+half of the SSRF guard that CVE-2026-46678 / CVE-2026-25580 had to harden. That
+is excessive agency (LLM06) on the host's network, not just the provider's.
 
 Finally, `end_strategy="exhaustive"` (PYD-105) changes what happens when the model
 emits a final result while tool calls are still pending: exhaustive mode runs those
@@ -160,6 +176,39 @@ egress controls — no tool source edit. **Confidence 0.75:** the rule flags the
 tool's presence, not a proven reachable internal target, so it over-flags agents
 that only ever fetch vetted external URLs or run behind a strict egress allow-list.
 
+### PYD-104 — FileUrl or WebFetchTool forces a host-side download (Severity: medium, Confidence: 0.8, Fix type: config)
+
+**What we detect:** a FileUrl-family constructor (`FileUrl` / `ImageUrl` /
+`AudioUrl` / `VideoUrl` / `DocumentUrl`) in the agent's file with
+`force_download=True` or `force_download="allow-local"` (predicate
+`agent_file_url_force_download`), or a wired `WebFetchTool` with the same kwarg
+(predicate `agent_hosted_tool_kwarg_value`). The default `False` is silent.
+
+**Why it is flaggable:** `force_download=True` makes the Pydantic AI *process*
+download the URL instead of passing it through to the model provider, so a
+prompt injection or a caller-supplied URL is fetched from the agent host —
+the SSRF surface Pydantic AI's own fetchers have already needed CVE fixes for
+(CVE-2026-46678, CVE-2026-25580). `"allow-local"` still downloads on the host
+and also permits private IPs, turning off the private-range half of that SSRF
+guard (cloud metadata stays blocked). That is excessive agency (LLM06) on the
+host's network.
+
+**Real-world consequence:** an HTTP endpoint accepts a client-submitted
+`DocumentUrl(..., force_download=True)`; the attacker points it at
+`http://169.254.169.254/` or an internal admin service, and the agent host
+fetches it. With `"allow-local"` the same path reaches RFC1918 addresses the
+default guard would have blocked.
+
+**Why severity is medium and not high:** `True` still runs the private-IP
+blocklist the CVEs hardened, so the worst metadata/private-IP hits need
+`"allow-local"` or a bypass the blocklist missed; impact also depends on
+whether the host can reach internal services at all. **Fix type — config:**
+leave `force_download` at `False`, or keep `True` only for URLs you control —
+no tool-body edit. **Confidence 0.8:** the kwarg match is precise, but
+discovery attributes a FileUrl to every Pydantic agent in the same file, so a
+multi-agent file over-flags agents that do not themselves construct the URL —
+the gap that holds it from 0.9.
+
 ### PYD-105 — Agent retries with the exhaustive end strategy (Severity: low, Confidence: 0.7, Fix type: config)
 
 **What we detect:** an `Agent` with `end_strategy="exhaustive"` (predicate
@@ -190,10 +239,14 @@ all read-only.
 - Hand-rolled URL fetches inside a tool body — caught by **PYD-005** (ssrf.md);
   PYD-103 covers only the native fetcher tools.
 - Whether the agent's prompt surface is actually reachable by untrusted content —
-  all four rules flag a configuration, not a proven injection path.
+  all five rules flag a configuration, not a proven injection path.
 - PYD-101 cannot tell whether a `str` output is consumed by code (risky) or only
   shown to a human (safe); PYD-105 cannot tell whether pending tools have side
   effects.
+- PYD-104 attributes a FileUrl-family constructor to every Pydantic agent in the
+  same file, so a multi-agent file over-flags; a FileUrl in a *different* file
+  from the Agent is silent. `force_download=False` (the default) is correctly
+  silent.
 - A native tool referenced under an alias, or a provider tool outside the listed
   class set, may escape the class-name match. Whether a native tool's execution or
   fetch environment is sandboxed is not visible to the match.
@@ -217,6 +270,7 @@ agent = Agent(
     end_strategy="early",        # skip pending tool calls once a result is final
     tools=[vetted_lookup],       # no CodeExecutionTool / WebFetchTool
 )
+# FileUrl-family: leave force_download at False (never "allow-local").
 ```
 
 1. Set `output_type` to a Pydantic model (or a typed union) wherever the result is
@@ -229,5 +283,11 @@ agent = Agent(
    egress controls around the agent process: a host allow-list, blocked
    private/link-local ranges, and a proxy that rejects internal addresses. Prefer a
    purpose-built fetcher over an open one.
-4. Leave `end_strategy` at `early` unless every callable tool is side-effect-free
+4. Leave `force_download` at its `False` default so URLs pass through to the
+   provider. Never set `"allow-local"` in production. If the host must download,
+   keep `True` only for URLs you control, and on any endpoint that accepts
+   client-submitted FileUrls run Pydantic AI's history sanitizer with
+   `allowed_file_url_force_download` left empty so `True` and `"allow-local"`
+   are reset.
+5. Leave `end_strategy` at `early` unless every callable tool is side-effect-free
    and you specifically need the remaining calls to complete.


### PR DESCRIPTION
## Summary
- Add **PYD-104** to `docs/Policy/pydantic_ai/agent_safety.md`: front-matter matches the shipped YAML (medium / 0.8 / agent / config), with a full defense block (host-side SSRF, CVE-2026-46678 / CVE-2026-25580, `"allow-local"` vs `True`, OWASP LLM06).
- Companion engine PR: https://github.com/trustabl/trustabl/pull/185

## Test plan
- [x] Front-matter severity / confidence / scope equal the YAML
- [ ] Reviewer: `python tools/check_rulebook.py` still reports the pre-existing OAI-112 / PYD-106 gaps (not introduced here)


Made with [Cursor](https://cursor.com)